### PR TITLE
feat: Add website count for modules in api.json

### DIFF
--- a/src/utils/update_stats.ts
+++ b/src/utils/update_stats.ts
@@ -250,6 +250,27 @@ async function updateAndCleanStats(options?: UpdateStatsOptions): Promise<void> 
             }
         }
 
+        // Process moduleWebsiteCounts to populate website count fields
+        for (const moduleName in moduleWebsiteCounts) { // moduleWebsiteCounts was populated earlier
+            const count: number = moduleWebsiteCounts[moduleName];
+
+            if (count < MIN_COUNT_THRESHOLD) {
+                continue;
+            }
+
+            if (moduleName.includes('BidAdapter')) {
+                finalApiData.bidAdapterWebsites[moduleName] = count;
+            } else if (moduleName.includes('IdSystem') || moduleName === 'userId' || moduleName === 'idImportLibrary' || moduleName === 'pubCommonId' || moduleName === 'utiqSystem' || moduleName === 'trustpidSystem') {
+                finalApiData.idModuleWebsites[moduleName] = count;
+            } else if (moduleName.includes('RtdProvider') || moduleName === 'rtdModule') {
+                finalApiData.rtdModuleWebsites[moduleName] = count;
+            } else if (moduleName.includes('AnalyticsAdapter')) {
+                finalApiData.analyticsAdapterWebsites[moduleName] = count;
+            } else {
+                finalApiData.otherModuleWebsites[moduleName] = count;
+            }
+        }
+
         const targetApiDir = path.dirname(finalApiFilePath);
         try {
             await fsPromises.access(targetApiDir);


### PR DESCRIPTION
This commit introduces a new metric to the `api.json` output, counting the number of unique websites that use each Prebid.js module.

Key changes:

- Modified `src/utils/update_stats.ts`:
    - Added logic to calculate unique website occurrences for each module. This ensures a module is counted only once per website, even if it appears in multiple Prebid instances on that site.
    - Introduced new fields in the `FinalApiData` interface and the output JSON (e.g., `bidAdapterWebsites`, `idModuleWebsites`, etc.) to store these website-specific counts.
    - These new counts are subject to the same `MIN_COUNT_THRESHOLD` as the instance counts.
- Updated `tests/stats.test.ts`:
    - Added new test cases to verify the website count functionality.
    - Test data was augmented to cover scenarios like a module appearing multiple times on the same site.
    - Assertions were added for the new `*Websites` fields in the output.

The logging was reviewed, and existing mechanisms were deemed sufficient for the new functionality.