### PR TITLE
refactor: Clean up comments in prebid.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ The `scan` command is used to analyze a list of websites for Prebid.js integrati
     -   Results are typically saved in a subdirectory structure like `output/Month/YYYY-MM-DD.json`.
 -   `--logDir <value>`: Specifies the directory where log files (`app.log`, `error.log`) will be saved.
     -   Default: `logs` (in the project root)
+-   `--range <string>`: Specify a line range (e.g., '10-20', '5-', '-15') to process from the input source (file, CSV, or GitHub-extracted URLs). Uses 1-based indexing. If the source is a GitHub repo, the range applies to the aggregated list of URLs extracted from all targeted files in the repo.
+    -   Example: `--range 10-50` or `--range 1-`
+-   `--chunkSize <number>`: Process URLs in chunks of this size. This processes all URLs (whether from the full input or a specified range) but does so by loading and analyzing only `chunkSize` URLs at a time. Useful for very large lists of URLs to manage resources or process incrementally.
+    -   Example: `--chunkSize 50`
 
 **Usage Examples:**
 
@@ -193,6 +197,11 @@ The `scan` command is used to analyze a list of websites for Prebid.js integrati
 9.  **Scan URLs from a remote CSV file (raw GitHub link):**
     ```bash
     ./bin/run scan --csvFile https://raw.githubusercontent.com/prebid/prebid-integration-monitor/main/tests/fixtures/sample_urls.csv
+    ```
+
+10. **Scan a specific range of URLs from a large input file, in chunks:**
+    ```bash
+    ./bin/run scan very_large_list_of_sites.txt --range 1001-2000 --chunkSize 100
     ```
 
 #### Notes on URL Extraction

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -51,6 +51,8 @@ export default class Scan extends Command {
       description: 'CSV file path or GitHub URL to fetch URLs from. Assumes URLs are in the first column.',
       required: false,
     }),
+    range: Flags.string({ description: "Specify a line range (e.g., '10-20' or '5-') to process from the input source. 1-based indexing.", required: false }),
+    chunkSize: Flags.integer({ description: "Process URLs in chunks of this size. Processes all URLs in the specified range or input, but one chunk at a time.", required: false }),
   }
 
   public async run(): Promise<void> {
@@ -143,6 +145,8 @@ export default class Scan extends Command {
       githubRepo: githubRepo, // Use the potentially modified variable
       csvFile: csvFile, // Add csvFile to options
       numUrls: flags.numUrls,
+      range: flags.range,
+      chunkSize: flags.chunkSize,
       puppeteerLaunchOptions: {
         headless: flags.headless, // Also set within puppeteerLaunchOptions for clarity/consistency
         args: [


### PR DESCRIPTION
This commit refactors comments within the `prebid.ts` file for clarity and conciseness.

Changes include:
- Simplified a calculation in a `sleep` call and removed the now-redundant comment.
- Condensed verbose comments in the `inputFile` update logic section to be more direct while retaining the core explanation of how remaining URLs are determined, especially in the context of ranged and chunked processing.