### PR TITLE
Fix: Ensure dummy_gh_input.txt is cleaned up after each test

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -91,6 +91,10 @@ describe('CLI Tests for Scan Command', () => {
         cleanup(testCsvFilePath); // Added for CSV tests
     });
 
+    afterEach(() => {
+        cleanup(dummyGithubInputFile);
+    });
+
     // Test Case 1
     it('Command runs with default options (now src/input.txt)', async () => {
         createInputFile(defaultInputFilePath, ['https://example.com']); // Will create src/input.txt


### PR DESCRIPTION
The `dummy_gh_input.txt` file, used in CLI tests, was previously cleaned up in `beforeAll`, `afterAll`, and `beforeEach` hooks, as well as in the specific test that creates it.

This change adds an `afterEach` hook to the main
`describe('CLI Tests for Scan Command', ...)` block to also clean up `dummyGithubInputFile`. This provides an additional layer of cleanup to ensure the file is removed after every test in the suite, addressing concerns that it might not be deleted if a test fails before its explicit cleanup call.