### PR TITLE
feat: Add tests for various GitHub file formats and document parsing …

### DIFF
--- a/src/prebid.ts
+++ b/src/prebid.ts
@@ -74,6 +74,13 @@ const puppeteer = addExtra(puppeteerVanilla as any);
 async function fetchUrlsFromGitHub(repoUrl: string, numUrls: number | undefined, logger: WinstonLogger): Promise<string[]> {
   logger.info(`Fetching URLs from GitHub repository source: ${repoUrl}`);
   const extractedUrls: string[] = [];
+  // TODO: Enhance URL extraction for specific file types. Currently, a general regex is used.
+  // This approach will identify fully qualified URLs in any text-based file.
+  // It does not specifically parse structured files like JSON (beyond finding embedded URLs)
+  // or automatically prepend schemes to schemeless domains (e.g., from simple domain lists in .txt files).
+  // For example:
+  //  - For domain lists in .txt files (e.g., IAB adstxt), domains without http(s):// prefixes won't be captured.
+  //  - For structured .json files (e.g., DuckDuckGo tracker radar), only fully qualified URLs present as strings are extracted, not data from specific JSON paths.
   const urlRegex = /(https?:\/\/[^\s"]+)/gi;
 
   try {


### PR DESCRIPTION
…limits

This commit introduces new tests to verify the `--githubRepo` flag's ability to fetch different file types, specifically `.txt` and `.json` files, using direct links to these files on GitHub.

Key changes:
- Added a test case for fetching IAB adstxt-style `.txt` files (containing domain lists) via a direct GitHub URL. The test confirms file download and acknowledges that the current regex-based URL extraction does not parse schemeless domains.
- Added a test case for fetching `.json` files (e.g., DuckDuckGo tracker radar) via a direct GitHub URL. The test confirms file download and that the current regex-based URL extraction will find fully qualified URLs within the JSON string content, but does not parse the JSON structure itself.
- Added a TODO comment in `src/prebid.ts` within the `fetchUrlsFromGitHub` function to highlight the current limitations of the generic URL extraction regex and suggest potential future enhancements for specific file types.
- Performed minor comment cleanup in `tests/cli.test.ts`.

The core URL extraction logic remains unchanged; the focus was on expanding test coverage for different file formats accessible via direct GitHub links and clearly documenting the existing parsing capabilities and limitations.