### PR TITLE
Okay, I've made some improvements to the JSDoc comments and the overa…

### DIFF
--- a/src/commands/scan-options.ts
+++ b/src/commands/scan-options.ts
@@ -1,0 +1,45 @@
+import {Args, Flags} from '@oclif/core';
+
+export const scanArgs = {
+  inputFile: Args.string({description: 'Input file path (accepts .txt, .csv, .json)', required: false, default: 'src/input.txt'}),
+};
+
+export const scanFlags = {
+  githubRepo: Flags.string({
+    description: 'GitHub repository URL to fetch URLs from',
+    required: false,
+  }),
+  numUrls: Flags.integer({
+    description: 'Number of URLs to load from the GitHub repository (used only with --githubRepo)',
+    default: 100,
+    required: false,
+  }),
+  puppeteerType: Flags.string({
+    description: 'Type of Puppeteer to use',
+    options: ['vanilla', 'cluster'],
+    default: 'cluster',
+  }),
+  concurrency: Flags.integer({
+    description: 'Number of concurrent Puppeteer instances',
+    default: 5,
+  }),
+  headless: Flags.boolean({
+    description: 'Run Puppeteer in headless mode',
+    default: true,
+    allowNo: true,
+  }),
+  monitor: Flags.boolean({
+    description: 'Enable puppeteer-cluster monitoring',
+    default: false,
+  }),
+  outputDir: Flags.string({
+    description: 'Directory to save output files',
+    default: 'store',
+  }),
+  logDir: Flags.string({
+    description: 'Directory to save log files',
+    default: 'logs',
+  }),
+  range: Flags.string({ description: "Specify a line range (e.g., '10-20' or '5-') to process from the input source. 1-based indexing.", required: false }),
+  chunkSize: Flags.integer({ description: "Process URLs in chunks of this size. Processes all URLs in the specified range or input, but one chunk at a time.", required: false }),
+};


### PR DESCRIPTION
…ll structure of the `scan` command.

I've refined the JSDoc comments in `src/commands/scan.ts` to be clearer and more complete, including adding parameter types for private methods.

I also did some further refactoring on the `scan` command by:
- Moving the `args` and `flags` static definitions into a new file: `src/commands/scan-options.ts`.
- Updating `src/commands/scan.ts` to import these definitions from the new file.

These adjustments should make the `scan` command easier to read, maintain, and understand.