### PR TITLE
Refactor: Further improve logger.ts formatting logic and JSDoc

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,10 +1,99 @@
-import winston, { Logger } from 'winston';
+/**
+ * @module logger
+ * @description This module provides a singleton Winston logger instance.
+ * It must be initialized by calling `initializeLogger` before use.
+ * The logger is configured to log to the console and to files (app.log, error.log).
+ * It also integrates with OpenTelemetry for tracing.
+ */
+import winston, { Logger, Logform } from 'winston';
 import fs from 'fs';
 import path from 'path';
 import { trace } from '@opentelemetry/api';
 
 let logger: Logger;
 
+/**
+ * A Winston log format that enriches the log `info` object with `trace_id` and `span_id`
+ * from an active OpenTelemetry span, if one exists.
+ *
+ * @param {Logform.TransformableInfo} info - The log information object implicitly passed by Winston.
+ * @returns {Logform.TransformableInfo} The modified log information object.
+ */
+const openTelemetryFormat = winston.format(info => {
+  const activeSpan = trace.getActiveSpan();
+  if (activeSpan) {
+    const spanContext = activeSpan.spanContext();
+    if (spanContext) {
+      info.trace_id = spanContext.traceId;
+      info.span_id = spanContext.spanId;
+    }
+  }
+  return info;
+});
+
+/**
+ * Formats Winston splat (`...rest`) metadata for console logging.
+ * It handles arrays by joining their elements (stringifying objects),
+ * objects by stringifying them (unless the result is '{}'),
+ * and primitives by converting them to strings.
+ *
+ * @param {any} splat - The splat data passed by Winston. This can be of any type.
+ * @returns {string} A string representation of the metadata, suitable for logging.
+ *                   Returns an empty string if the splat data is trivial (e.g., undefined, empty array, or empty object stringification).
+ */
+function formatSplatMetadata(splat: any): string {
+  if (Array.isArray(splat)) {
+    const metadata = splat.map((s: any) => typeof s === 'object' ? JSON.stringify(s) : s).join(' ');
+    return metadata || ''; // Return empty string if metadata is empty after join
+  } else if (typeof splat === 'object' && splat !== null) {
+    const metadataString = JSON.stringify(splat);
+    return (metadataString && metadataString !== '{}') ? metadataString : '';
+  } else if (splat !== undefined) {
+    return String(splat);
+  }
+  return '';
+}
+
+/**
+ * Formats a log message for console output.
+ * @param {Logform.TransformableInfo} info - The log information object.
+ * @returns {string} The formatted log message.
+ */
+function formatConsoleLogMessage(info: Logform.TransformableInfo): string {
+  let message = `${info.timestamp} ${info.level}: ${info.message}`;
+  if (info.stack) {
+    message += `\n${info.stack}`;
+  }
+
+  const activeSpan = trace.getActiveSpan();
+  if (activeSpan) {
+    const spanContext = activeSpan.spanContext();
+    if (spanContext) {
+      message += ` (trace_id: ${spanContext.traceId}, span_id: ${spanContext.spanId})`;
+    }
+  }
+
+  if (typeof info.message === 'string' && info.message.startsWith('Initial URLs read from') && typeof info.count === 'number') {
+    message += ` count: ${info.count}`;
+  } else {
+    const splat = info[Symbol.for('splat')];
+    const metadataString = formatSplatMetadata(splat);
+    if (metadataString) {
+      message += ` ${metadataString}`;
+    }
+  }
+  return message;
+}
+
+/**
+ * Initializes the Winston logger instance.
+ * Creates the log directory if it doesn't exist.
+ *
+ * @param {string} logDir - The directory where log files will be stored.
+ * @returns {Logger} The initialized Winston logger instance.
+ * @throws {Error} If an error occurs during logger initialization.
+ * @sideEffects Creates the log directory if it doesn't exist.
+ */
 export function initializeLogger(logDir: string): Logger {
   if (!fs.existsSync(logDir)) {
     fs.mkdirSync(logDir, { recursive: true });
@@ -22,61 +111,14 @@ export function initializeLogger(logDir: string): Logger {
       level: process.env.LOG_LEVEL_CONSOLE || 'info',
       format: winston.format.combine(
         winston.format.colorize(),
-        winston.format.printf(info => {
-          let message = `${info.timestamp} ${info.level}: ${info.message}`;
-          if (info.stack) {
-            message += `\n${info.stack}`;
-          }
-
-          const activeSpan = trace.getActiveSpan();
-          if (activeSpan) {
-            const spanContext = activeSpan.spanContext();
-            if (spanContext) {
-              message += ` (trace_id: ${spanContext.traceId}, span_id: ${spanContext.spanId})`;
-            }
-          }
-
-          if (typeof info.message === 'string' && info.message.startsWith('Initial URLs read from') && typeof info.count === 'number') {
-            message += ` count: ${info.count}`;
-          } else {
-            const splat = info[Symbol.for('splat')];
-            if (splat) {
-              if (Array.isArray(splat)) {
-                const metadata = splat.map((s: any) => typeof s === 'object' ? JSON.stringify(s) : s).join(' ');
-                if (metadata) {
-                  message += ` ${metadata}`;
-                }
-              } else if (typeof splat === 'object' && splat !== null) {
-                const metadataString = JSON.stringify(splat);
-                if (metadataString && metadataString !== '{}') {
-                   if (!(typeof info.message === 'string' && info.message.startsWith('Initial URLs read from') && info.urls && typeof info.count === 'number')) {
-                    message += ` ${metadataString}`;
-                  }
-                }
-              } else {
-                message += ` ${splat}`;
-              }
-            }
-          }
-          return message;
-        })
+        winston.format.printf(formatConsoleLogMessage)
       )
     }),
     new winston.transports.File({
       filename: path.join(logDir, 'app.log'),
       level: process.env.LOG_LEVEL_APP || 'info',
       format: winston.format.combine(
-        winston.format(info => {
-          const activeSpan = trace.getActiveSpan();
-          if (activeSpan) {
-            const spanContext = activeSpan.spanContext();
-            if (spanContext) {
-              info.trace_id = spanContext.traceId;
-              info.span_id = spanContext.spanId;
-            }
-          }
-          return info;
-        })(),
+        openTelemetryFormat(),
         winston.format.json()
       )
     }),
@@ -84,17 +126,7 @@ export function initializeLogger(logDir: string): Logger {
       filename: path.join(logDir, 'error.log'),
       level: 'error',
       format: winston.format.combine(
-        winston.format(info => {
-          const activeSpan = trace.getActiveSpan();
-          if (activeSpan) {
-            const spanContext = activeSpan.spanContext();
-            if (spanContext) {
-              info.trace_id = spanContext.traceId;
-              info.span_id = spanContext.spanId;
-            }
-          }
-          return info;
-        })(),
+        openTelemetryFormat(),
         winston.format.json()
       )
     })
@@ -107,6 +139,12 @@ export function initializeLogger(logDir: string): Logger {
 }
 
 export default {
+  /**
+   * Gets the singleton logger instance.
+   *
+   * @returns {Logger} The Winston logger instance.
+   * @throws {Error} If `initializeLogger` has not been called.
+   */
   get instance() {
     if (!logger) {
       throw new Error("Logger has not been initialized. Call initializeLogger(logDir) first.");


### PR DESCRIPTION
This commit introduces further an improved `logger.ts`:

- Refactored `formatConsoleLogMessage`:
    - Extracted the complex splat/metadata processing logic into a new dedicated helper function `formatSplatMetadata`.
    - This simplifies `formatConsoleLogMessage` and makes the metadata formatting logic more modular and understandable.
    - Removed a redundant conditional check within the splat handling part of `formatConsoleLogMessage`.

- Enhanced JSDoc Comments:
    - Added detailed JSDoc for the new `formatSplatMetadata` function, explaining its parameters, return value, and behavior for different splat types.
    - Reviewed and improved JSDoc for the existing `openTelemetryFormat` Winston format function for clarity.

These changes contribute to better code quality, readability, and maintainability of the logging utility.