### PR TITLE
feat: Add ESLint and Prettier for code linting and formatting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  plugins: ['@typescript-eslint', 'prettier'],
+  rules: {
+    'prettier/prettier': 'error',
+  },
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.eslintrc.cjs
+.gitignore

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 80,
+  tabWidth: 2,
+};

--- a/README.md
+++ b/README.md
@@ -285,6 +285,39 @@ npx -p vitest vitest run
 
 This will execute all tests found in the `tests/` directory.
 
+## Linting and Formatting
+
+This project uses ESLint for linting and Prettier for code formatting to ensure code quality and consistency.
+
+### Configuration
+
+-   **ESLint**: Configuration is managed in `eslint.config.js`. It uses `@typescript-eslint/parser` for TypeScript support and integrates Prettier rules to avoid conflicts.
+-   **Prettier**: Configuration is managed in `.prettierrc.cjs`.
+-   **Ignore Files**:
+    -   `.eslintignore` (if you choose to create one, though `ignores` in `eslint.config.js` is preferred for ESLint v9+).
+    -   `.prettierignore` is used to specify files that Prettier should not format.
+
+### Scripts
+
+-   **To format all supported files in the project:**
+    ```bash
+    npm run format
+    ```
+    This command uses Prettier to rewrite files in place according to the rules in `.prettierrc.cjs`.
+
+-   **To lint all TypeScript files and automatically fix fixable issues:**
+    ```bash
+    npm run lint -- --fix
+    ```
+    This command uses ESLint to analyze the code. The `--fix` flag instructs ESLint to automatically correct problems where possible. Any errors that cannot be auto-fixed will be reported in the console.
+
+-   **To check for linting errors without fixing:**
+    ```bash
+    npm run lint
+    ```
+
+It's recommended to run these scripts before committing code to maintain a clean and consistent codebase.
+
 ## Logging
 
 This application utilizes the Winston logging library to provide detailed and structured logging.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+import typescriptParser from '@typescript-eslint/parser';
+import typescriptPlugin from '@typescript-eslint/eslint-plugin';
+import prettierPlugin from 'eslint-plugin-prettier';
+import prettierConfig from 'eslint-config-prettier';
+
+export default [
+  {
+    files: ['**/*.ts'], // Apply this configuration to all TypeScript files
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptPlugin,
+      prettier: prettierPlugin,
+    },
+    rules: {
+      ...typescriptPlugin.configs.recommended.rules,
+      ...prettierConfig.rules, // Apply Prettier's rules
+      'prettier/prettier': 'error', // Report Prettier violations as ESLint errors
+    },
+  },
+  {
+    // Ignores configuration for non-JS/TS files if Prettier was complaining
+    // This is a guess, may need adjustment if Prettier issues persist for other file types
+    ignores: ["**/*.md", "**/*.json", "**/*.yaml", "**/*.yml", ".prettierrc.cjs", ".eslintrc.cjs"],
+  }
+];

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -987,6 +987,134 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/core": "^0.14.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.2.tgz",
@@ -1027,6 +1155,67 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -2269,6 +2458,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@oclif/core": {
@@ -3688,6 +3912,18 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -4707,6 +4943,12 @@
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
@@ -4808,6 +5050,253 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
+      "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/type-utils": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.33.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
+      "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
+      "integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.33.1",
+        "@typescript-eslint/types": "^8.33.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
+      "integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
+      "integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.1.tgz",
+      "integrity": "sha512-1cG37d9xOkhlykom55WVwG2QRNC7YXlxMaMzqw2uPeJixBFfKWZgaP/hjAObqMN/u3fr5BrTwTnc31/L9jQ2ww==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
+      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.33.1",
+        "@typescript-eslint/tsconfig-utils": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
+      "integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.33.1",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -4936,6 +5425,15 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -4956,6 +5454,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -5563,6 +6077,50 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/cross-spawn/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csv-parse": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
@@ -5634,6 +6192,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -5851,6 +6415,271 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
+      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.28.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
+      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -5861,6 +6690,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -5935,10 +6788,56 @@
         "@types/yauzl": "^2.9.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "3.0.0",
@@ -5978,6 +6877,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fd-slicer": {
@@ -6030,6 +6938,18 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -6069,6 +6989,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-yarn-workspace-root": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
@@ -6077,6 +7013,25 @@
       "dependencies": {
         "micromatch": "^4.0.2"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -6291,6 +7246,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-logging-utils": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
@@ -6340,6 +7319,12 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -6490,6 +7475,15 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6514,6 +7508,15 @@
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -6602,12 +7605,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -6816,6 +7840,18 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -6860,6 +7896,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -6891,6 +7940,21 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -6901,6 +7965,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -7012,6 +8082,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
@@ -7132,6 +8211,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -9952,6 +11037,29 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/optionator/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -9968,6 +11076,36 @@
       "dev": true,
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -10056,6 +11194,15 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -10210,6 +11357,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/proc-log": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -10285,6 +11468,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -10504,6 +11696,26 @@
         }
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -10619,6 +11831,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -10670,6 +11892,29 @@
         "@rollup/rollup-win32-ia32-msvc": "4.41.1",
         "@rollup/rollup-win32-x64-msvc": "4.41.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -10758,6 +12003,27 @@
       "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shimmer": {
@@ -10986,6 +12252,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -11018,6 +12296,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/tar-fs": {
@@ -11160,6 +12453,18 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -11217,6 +12522,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -11345,6 +12662,15 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -11658,6 +12984,15 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -11815,6 +13150,18 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors-cjs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,14 @@
       "devDependencies": {
         "@oclif/core": "^4.3.1",
         "@types/node": "^20.14.13",
+        "@typescript-eslint/eslint-plugin": "^8.33.1",
+        "@typescript-eslint/parser": "^8.33.1",
+        "eslint": "^9.28.0",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-prettier": "^5.4.1",
         "mock-fs": "^5.5.0",
         "oclif": "^4.17.46",
+        "prettier": "^3.5.3",
         "typedoc": "^0.28.5",
         "typedoc-plugin-markdown": "^4.6.4",
         "vitest": "^3.2.0"
@@ -1410,6 +1416,134 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "dev": true,
+      "dependencies": {
+        "@eslint/core": "^0.14.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.2.tgz",
@@ -1450,6 +1584,67 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -2692,6 +2887,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@oclif/core": {
@@ -4111,6 +4341,18 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -5364,6 +5606,12 @@
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
@@ -5465,6 +5713,253 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
+      "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/type-utils": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.33.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
+      "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
+      "integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.33.1",
+        "@typescript-eslint/types": "^8.33.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
+      "integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
+      "integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.1.tgz",
+      "integrity": "sha512-1cG37d9xOkhlykom55WVwG2QRNC7YXlxMaMzqw2uPeJixBFfKWZgaP/hjAObqMN/u3fr5BrTwTnc31/L9jQ2ww==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
+      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.33.1",
+        "@typescript-eslint/tsconfig-utils": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
+      "integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.33.1",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -5593,6 +6088,15 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -5613,6 +6117,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -6220,6 +6740,50 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/cross-spawn/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csv-parse": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
@@ -6291,6 +6855,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -6508,6 +7078,271 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
+      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.28.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
+      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -6518,6 +7353,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -6592,10 +7451,56 @@
         "@types/yauzl": "^2.9.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
+    },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "3.0.0",
@@ -6635,6 +7540,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fd-slicer": {
@@ -6687,6 +7601,18 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -6726,6 +7652,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-yarn-workspace-root": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
@@ -6734,6 +7676,25 @@
       "dependencies": {
         "micromatch": "^4.0.2"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -6962,6 +7923,30 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-logging-utils": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
@@ -7011,6 +7996,12 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -7161,6 +8152,15 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -7185,6 +8185,15 @@
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -7273,12 +8282,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -7487,6 +8517,18 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -7531,6 +8573,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -7562,6 +8617,21 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -7572,6 +8642,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -7683,6 +8759,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
@@ -7803,6 +8888,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -10623,6 +11714,29 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/optionator/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -10639,6 +11753,36 @@
       "dev": true,
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -10727,6 +11871,15 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -10881,6 +12034,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/proc-log": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -10956,6 +12145,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -11175,6 +12373,26 @@
         }
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -11290,6 +12508,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11341,6 +12569,29 @@
         "@rollup/rollup-win32-ia32-msvc": "4.41.1",
         "@rollup/rollup-win32-x64-msvc": "4.41.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -11429,6 +12680,27 @@
       "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/shimmer": {
@@ -11657,6 +12929,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -11689,6 +12973,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/tar-fs": {
@@ -11831,6 +13130,18 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -11888,6 +13199,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -12016,6 +13339,15 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -12329,6 +13661,15 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -12486,6 +13827,18 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors-cjs": {
@@ -13509,6 +14862,94 @@
       "dev": true,
       "optional": true
     },
+    "@eslint-community/eslint-utils": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.4.3"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true
+    },
+    "@eslint/config-array": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "dev": true,
+      "requires": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      }
+    },
+    "@eslint/config-helpers": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "dev": true
+    },
+    "@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.15"
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+          "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+          "dev": true
+        }
+      }
+    },
+    "@eslint/js": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "dev": true
+    },
+    "@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true
+    },
+    "@eslint/plugin-kit": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "dev": true,
+      "requires": {
+        "@eslint/core": "^0.14.0",
+        "levn": "^0.4.1"
+      }
+    },
     "@gerrit0/mini-shiki": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.2.tgz",
@@ -13541,6 +14982,42 @@
         "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       }
+    },
+    "@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true
+    },
+    "@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "requires": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "dependencies": {
+        "@humanwhocodes/retry": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+          "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+          "dev": true
+        }
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true
+    },
+    "@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true
     },
     "@inquirer/checkbox": {
       "version": "4.1.8",
@@ -14352,6 +15829,32 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
     },
     "@oclif/core": {
       "version": "4.3.1",
@@ -15286,6 +16789,12 @@
       "requires": {
         "@opentelemetry/core": "^2.0.0"
       }
+    },
+    "@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true
     },
     "@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -16248,6 +17757,12 @@
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
@@ -16351,6 +17866,150 @@
         "@types/node": "*"
       }
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
+      "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/type-utils": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
+      "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/project-service": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
+      "integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/tsconfig-utils": "^8.33.1",
+        "@typescript-eslint/types": "^8.33.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
+      "integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1"
+      }
+    },
+    "@typescript-eslint/tsconfig-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
+      "integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
+      "dev": true,
+      "requires": {}
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.1.tgz",
+      "integrity": "sha512-1cG37d9xOkhlykom55WVwG2QRNC7YXlxMaMzqw2uPeJixBFfKWZgaP/hjAObqMN/u3fr5BrTwTnc31/L9jQ2ww==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "8.33.1",
+        "@typescript-eslint/utils": "8.33.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
+      "integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
+      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/project-service": "8.33.1",
+        "@typescript-eslint/tsconfig-utils": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/visitor-keys": "8.33.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
+      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.33.1",
+        "@typescript-eslint/types": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.33.1"
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "8.33.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
+      "integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "8.33.1",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+          "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+          "dev": true
+        }
+      }
+    },
     "@vitest/expect": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.0.tgz",
@@ -16436,6 +18095,13 @@
       "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "requires": {}
     },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "requires": {}
+    },
     "acorn-walk": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
@@ -16450,6 +18116,18 @@
       "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "requires": {
         "debug": "^4.3.4"
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-escapes": {
@@ -16892,6 +18570,40 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
+    "cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "csv-parse": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.6.0.tgz",
@@ -16936,6 +18648,12 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
     "deepmerge": {
@@ -17096,10 +18814,192 @@
         "source-map": "~0.6.1"
       }
     },
+    "eslint": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
+      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.28.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.3.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+          "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.3.2",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+          "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-prettier": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.1.tgz",
+      "integrity": "sha512-9dF+KuU/Ilkq27A8idRP7N2DH8iUR6qXcjF3FR2wETY21PZdBrIjwCau8oboyGj9b7etWmTGEeM8e7oOed6ZWg==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      }
+    },
+    "eslint-scope": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
+      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true
+    },
+    "espree": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.14.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+          "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
     },
     "estraverse": {
       "version": "5.3.0",
@@ -17153,10 +19053,52 @@
         "yauzl": "^2.10.0"
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true
+    },
     "fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
+    "fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "3.0.0",
@@ -17181,6 +19123,15 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -17208,6 +19159,15 @@
       "requires": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^4.0.0"
       }
     },
     "filelist": {
@@ -17245,6 +19205,16 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "find-yarn-workspace-root": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
@@ -17253,6 +19223,22 @@
       "requires": {
         "micromatch": "^4.0.2"
       }
+    },
+    "flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      }
+    },
+    "flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
     },
     "fn.name": {
       "version": "1.1.0",
@@ -17410,6 +19396,21 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true
+    },
     "google-logging-utils": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
@@ -17446,6 +19447,12 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -17559,6 +19566,12 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -17578,6 +19591,12 @@
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -17641,10 +19660,25 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-number": {
       "version": "7.0.0",
@@ -17794,6 +19828,18 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -17830,6 +19876,16 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="
     },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
     "lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -17854,6 +19910,15 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -17864,6 +19929,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "logform": {
       "version": "2.7.0",
@@ -17959,6 +20030,12 @@
         "kind-of": "^3.0.2"
       }
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -18038,6 +20115,12 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "netmask": {
@@ -19873,6 +21956,28 @@
         "fn.name": "1.x.x"
       }
     },
+    "optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "dependencies": {
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+          "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+          "dev": true
+        }
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -19884,6 +21989,24 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
       "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
       "dev": true
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
     },
     "pac-proxy-agent": {
       "version": "7.0.1",
@@ -19957,6 +22080,12 @@
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -20056,6 +22185,27 @@
         "xtend": "^4.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "proc-log": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
@@ -20119,6 +22269,12 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true
     },
     "punycode.js": {
       "version": "2.3.1",
@@ -20230,6 +22386,12 @@
         "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
       }
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -20306,6 +22468,12 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -20342,6 +22510,15 @@
         "@rollup/rollup-win32-x64-msvc": "4.41.1",
         "@types/estree": "1.0.7",
         "fsevents": "~2.3.2"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -20401,6 +22578,21 @@
           "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ=="
         }
       }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "shimmer": {
       "version": "1.2.1",
@@ -20592,6 +22784,12 @@
         "ansi-regex": "^5.0.1"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
     "strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -20610,6 +22808,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "requires": {
+        "@pkgr/core": "^0.2.4"
+      }
     },
     "tar-fs": {
       "version": "3.0.9",
@@ -20723,6 +22930,13 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
     },
+    "ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "requires": {}
+    },
     "ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -20755,6 +22969,15 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
       }
     },
     "type-fest": {
@@ -20848,6 +23071,15 @@
       "dev": true,
       "requires": {
         "tslib": "^2.0.3"
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
       }
     },
     "urlpattern-polyfill": {
@@ -21017,6 +23249,12 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -21119,6 +23357,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     },
     "yoctocolors-cjs": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "dev": "node --loader ts-node/esm ./bin/dev.js default",
     "scan": "npm run build && node ./bin/run.js scan",
     "prebid:scan": "node ./bin/run.js scan",
-    "docs:generate": "typedoc --options typedoc.json"
+    "docs:generate": "typedoc --options typedoc.json",
+    "lint": "eslint . --ext .ts",
+    "format": "prettier --write ."
   },
   "repository": {
     "type": "git",
@@ -50,8 +52,14 @@
   "devDependencies": {
     "@oclif/core": "^4.3.1",
     "@types/node": "^20.14.13",
+    "@typescript-eslint/eslint-plugin": "^8.33.1",
+    "@typescript-eslint/parser": "^8.33.1",
+    "eslint": "^9.28.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.4.1",
     "mock-fs": "^5.5.0",
     "oclif": "^4.17.46",
+    "prettier": "^3.5.3",
     "typedoc": "^0.28.5",
     "typedoc-plugin-markdown": "^4.6.4",
     "vitest": "^3.2.0"

--- a/src/commands/default.ts
+++ b/src/commands/default.ts
@@ -1,4 +1,4 @@
-import {Command, Flags} from '@oclif/core';
+import { Command, Flags } from '@oclif/core';
 import { initTracer } from '../tracer.js';
 import loggerModule, { initializeLogger } from '../utils/logger.js';
 import type { Logger as WinstonLogger } from 'winston';
@@ -15,7 +15,8 @@ export default class Default extends Command {
    * A brief description of what the command does.
    * This is displayed when running `prebid-integration-monitor --help`.
    */
-  static description = 'Default command for prebid-integration-monitor. Runs the main monitoring logic.'
+  static description =
+    'Default command for prebid-integration-monitor. Runs the main monitoring logic.';
 
   // Add a logDir flag similar to the scan command for consistency
   /**
@@ -46,15 +47,17 @@ export default class Default extends Command {
    * @returns {Promise<void>} A promise that resolves when the command has finished executing.
    */
   async run(): Promise<void> {
-    const {flags} = await this.parse(Default);
+    const { flags } = await this.parse(Default);
     // Initialize logger with the logDir from flags
     logger = initializeLogger(flags.logDir);
-    logger.info('TEST_CONSOLE_OUTPUT: This is a test message from default command.');
+    logger.info(
+      'TEST_CONSOLE_OUTPUT: This is a test message from default command.',
+    );
 
     try {
       // Initialize the tracer as the first step
       initTracer();
-      logger.info("Default oclif command starting...");
+      logger.info('Default oclif command starting...');
 
       // Call the refactored monitoring logic
       // Pass logger and this.log to the service
@@ -65,10 +68,9 @@ export default class Default extends Command {
       // and are now handled within executeMonitoringLogic or are implicitly covered.
       // logger.info('Main application processing finished (oclif command).');
       // this.log('Main application processing finished (oclif command).');
-
     } catch (error) {
       logger.error('Error in oclif command execution:', error);
-      this.error(error as Error, {exit: 1});
+      this.error(error as Error, { exit: 1 });
     }
   }
 }

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1,6 +1,6 @@
-import {Args, Command, Flags} from '@oclif/core'
+import { Args, Command, Flags } from '@oclif/core';
 import fetch from 'node-fetch';
-import {mkdir, writeFile} from 'fs/promises';
+import { mkdir, writeFile } from 'fs/promises';
 import * as path from 'path';
 import { URL } from 'url';
 
@@ -16,15 +16,16 @@ export default class Inspect extends Command {
       description: 'URL to inspect.',
       required: true,
     }),
-  }
+  };
 
-  static override description = 'Inspects a URL and stores the request/response data. Supports JSON and HAR (basic) formats.'
+  static override description =
+    'Inspects a URL and stores the request/response data. Supports JSON and HAR (basic) formats.';
 
   static override examples = [
     '<%= config.bin %> <%= command.id %> https://example.com',
     '<%= config.bin %> <%= command.id %> https://example.com --output-dir store/custom-inspect --format har --filename my-inspection',
     '<%= config.bin %> <%= command.id %> https://api.example.com/data --filename api-data --format json',
-  ]
+  ];
 
   static override flags = {
     'output-dir': Flags.string({
@@ -32,15 +33,17 @@ export default class Inspect extends Command {
       default: 'store/inspect',
     }),
     format: Flags.string({
-      description: 'Format to store the data (json, har). HAR implementation is currently basic.',
+      description:
+        'Format to store the data (json, har). HAR implementation is currently basic.',
       default: 'json',
       options: ['json', 'har'],
     }),
     filename: Flags.string({
-      description: 'Filename for the inspection data (without extension). If not provided, it will be derived from the URL and timestamp.',
+      description:
+        'Filename for the inspection data (without extension). If not provided, it will be derived from the URL and timestamp.',
       required: false,
     }),
-  }
+  };
 
   /**
    * Runs the inspect command.
@@ -49,13 +52,13 @@ export default class Inspect extends Command {
    * @returns {Promise<void>} A promise that resolves when the command execution is complete.
    */
   public async run(): Promise<void> {
-    const {args, flags} = await this.parse(Inspect)
+    const { args, flags } = await this.parse(Inspect);
 
-    this.log(`Inspecting URL: ${args.url}`)
-    this.log(`Output directory: ${flags['output-dir']}`)
-    this.log(`Format: ${flags.format}`)
+    this.log(`Inspecting URL: ${args.url}`);
+    this.log(`Output directory: ${flags['output-dir']}`);
+    this.log(`Format: ${flags.format}`);
     if (flags.filename) {
-      this.log(`Custom filename specified: ${flags.filename}.${flags.format}`)
+      this.log(`Custom filename specified: ${flags.filename}.${flags.format}`);
     }
 
     try {
@@ -94,7 +97,9 @@ export default class Inspect extends Command {
       if (!outputFilenameBase) {
         const urlObject = new URL(args.url);
         // Sanitize hostname to be used in filename
-        const hostname = urlObject.hostname.replace(/[^a-z0-9_.-]/gi, '_').toLowerCase();
+        const hostname = urlObject.hostname
+          .replace(/[^a-z0-9_.-]/gi, '_')
+          .toLowerCase();
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         outputFilenameBase = `${hostname}-${timestamp}`;
         this.log(`Generated filename base: ${outputFilenameBase}`);
@@ -135,10 +140,14 @@ export default class Inspect extends Command {
                   statusText: inspectionData.response.statusText,
                   httpVersion: 'HTTP/1.1', // Placeholder
                   cookies: [], // Placeholder
-                  headers: Object.entries(inspectionData.response.headers).map(([name, value]) => ({name, value})),
+                  headers: Object.entries(inspectionData.response.headers).map(
+                    ([name, value]) => ({ name, value }),
+                  ),
                   content: {
                     size: responseBody.length,
-                    mimeType: inspectionData.response.headers['content-type'] || 'application/octet-stream',
+                    mimeType:
+                      inspectionData.response.headers['content-type'] ||
+                      'application/octet-stream',
                     text: responseBody, // HAR spec allows for text content
                   },
                   redirectURL: response.headers.get('location') || '',
@@ -154,12 +163,14 @@ export default class Inspect extends Command {
         await writeFile(outputPath, JSON.stringify(harOutput, null, 2));
         this.log(`Inspection data (basic HAR) saved to: ${outputPath}`);
       } else {
-        this.error(`Unsupported format: ${flags.format}`, {exit: 1});
+        this.error(`Unsupported format: ${flags.format}`, { exit: 1 });
         return;
       }
-
     } catch (error: any) {
-      this.error(`Error during inspection: ${error.message} (URL: ${args.url})`, {exit: 1});
+      this.error(
+        `Error during inspection: ${error.message} (URL: ${args.url})`,
+        { exit: 1 },
+      );
     }
   }
 }

--- a/src/commands/scan-options.ts
+++ b/src/commands/scan-options.ts
@@ -1,7 +1,11 @@
-import {Args, Flags} from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 
 export const scanArgs = {
-  inputFile: Args.string({description: 'Input file path (accepts .txt, .csv, .json)', required: false, default: 'src/input.txt'}),
+  inputFile: Args.string({
+    description: 'Input file path (accepts .txt, .csv, .json)',
+    required: false,
+    default: 'src/input.txt',
+  }),
 };
 
 export const scanFlags = {
@@ -10,7 +14,8 @@ export const scanFlags = {
     required: false,
   }),
   numUrls: Flags.integer({
-    description: 'Number of URLs to load from the GitHub repository (used only with --githubRepo)',
+    description:
+      'Number of URLs to load from the GitHub repository (used only with --githubRepo)',
     default: 100,
     required: false,
   }),
@@ -40,6 +45,14 @@ export const scanFlags = {
     description: 'Directory to save log files',
     default: 'logs',
   }),
-  range: Flags.string({ description: "Specify a line range (e.g., '10-20' or '5-') to process from the input source. 1-based indexing.", required: false }),
-  chunkSize: Flags.integer({ description: "Process URLs in chunks of this size. Processes all URLs in the specified range or input, but one chunk at a time.", required: false }),
+  range: Flags.string({
+    description:
+      "Specify a line range (e.g., '10-20' or '5-') to process from the input source. 1-based indexing.",
+    required: false,
+  }),
+  chunkSize: Flags.integer({
+    description:
+      'Process URLs in chunks of this size. Processes all URLs in the specified range or input, but one chunk at a time.',
+    required: false,
+  }),
 };

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,4 +1,4 @@
-import {Command, Flags, Args, Interfaces} from '@oclif/core'; // Added Interfaces
+import { Command, Flags, Args, Interfaces } from '@oclif/core'; // Added Interfaces
 // Step 1: Import prebidExplorer and PrebidExplorerOptions
 import { prebidExplorer, PrebidExplorerOptions } from '../prebid.js'; // Assuming .js for NodeNext resolution
 import { scanArgs, scanFlags } from './scan-options.js';
@@ -15,14 +15,15 @@ export default class Scan extends Command {
   /**
    * Provides a description for the Scan command.
    */
-  static override description = 'Scans websites for Prebid.js integrations. InputFile can be .txt, .csv, or .json.'
+  static override description =
+    'Scans websites for Prebid.js integrations. InputFile can be .txt, .csv, or .json.';
   /**
    * Provides examples of how to use the Scan command.
    */
   static override examples = [
     '<%= config.bin %> <%= command.id %> websites.txt --puppeteerType=cluster --concurrency=10',
     '<%= config.bin %> <%= command.id %> --githubRepo https://github.com/user/repo --numUrls 50',
-  ]
+  ];
   /**
    * Defines the flags for the Scan command.
    */
@@ -39,7 +40,9 @@ export default class Scan extends Command {
    * @param flags - The parsed flags object obtained from `this.parse(Scan)`. Expected to conform to the structure defined in `Scan.flags`.
    * @returns A {@link PrebidExplorerOptions} object configured with values from the flags.
    */
-  private _getPrebidExplorerOptions(flags: Interfaces.InferredFlags<typeof Scan.flags>): PrebidExplorerOptions {
+  private _getPrebidExplorerOptions(
+    flags: Interfaces.InferredFlags<typeof Scan.flags>,
+  ): PrebidExplorerOptions {
     return {
       puppeteerType: flags.puppeteerType as 'vanilla' | 'cluster',
       concurrency: flags.concurrency,
@@ -67,23 +70,32 @@ export default class Scan extends Command {
    * @param flags - The parsed flags object obtained from `this.parse(Scan)`. Expected to conform to the structure defined in `Scan.flags`.
    * @param options - The {@link PrebidExplorerOptions} object to be modified with input source details.
    */
-  private _getInputSourceOptions(args: Interfaces.InferredArgs<typeof Scan.args>, flags: Interfaces.InferredFlags<typeof Scan.flags>, options: PrebidExplorerOptions): void {
+  private _getInputSourceOptions(
+    args: Interfaces.InferredArgs<typeof Scan.args>,
+    flags: Interfaces.InferredFlags<typeof Scan.flags>,
+    options: PrebidExplorerOptions,
+  ): void {
     if (flags.githubRepo) {
       this.log(`Fetching URLs from GitHub repository: ${flags.githubRepo}`);
       options.githubRepo = flags.githubRepo;
       if (args.inputFile && args.inputFile !== 'src/input.txt') {
-        this.warn(`--githubRepo provided, inputFile argument ('${args.inputFile}') will be ignored.`);
+        this.warn(
+          `--githubRepo provided, inputFile argument ('${args.inputFile}') will be ignored.`,
+        );
       }
     } else if (args.inputFile) {
       this.log(`Using input file: ${args.inputFile}`);
       options.inputFile = args.inputFile;
     } else {
-      this.error('No input source specified. Please provide --githubRepo or an inputFile argument.', { exit: 1 });
+      this.error(
+        'No input source specified. Please provide --githubRepo or an inputFile argument.',
+        { exit: 1 },
+      );
     }
   }
 
   public async run(): Promise<void> {
-    const {args, flags} = await this.parse(Scan)
+    const { args, flags } = await this.parse(Scan);
 
     const options = this._getPrebidExplorerOptions(flags);
     this._getInputSourceOptions(args, flags, options);

--- a/src/commands/stats/generate.ts
+++ b/src/commands/stats/generate.ts
@@ -17,7 +17,8 @@ export default class StatsGenerate extends Command {
    * Description of the stats:generate command.
    * This description is displayed when listing commands or showing help for this command.
    */
-  static override description = 'Generates or updates the API statistics file (api/api.json) by processing stored website scan data. This includes summarizing data, cleaning it, and applying version and module categorization.';
+  static override description =
+    'Generates or updates the API statistics file (api/api.json) by processing stored website scan data. This includes summarizing data, cleaning it, and applying version and module categorization.';
 
   /**
    * Examples of how to use the stats:generate command.
@@ -50,14 +51,17 @@ export default class StatsGenerate extends Command {
       this.log('The file api/api.json has been updated.');
     } catch (error: any) {
       // Log the error in a more structured way if possible
-      this.error(`An error occurred during statistics generation: ${error.message}`, {
-        exit: 1, // oclif recommends exiting with a non-zero code on error
-        suggestions: [
-          'Check the console output for more details from the updateAndCleanStats script.',
-          'Ensure that the scan data directory (typically \'store\') contains valid JSON files.',
-          'Verify file permissions for reading scan data and writing to the \'api\' directory.',
-        ],
-      });
+      this.error(
+        `An error occurred during statistics generation: ${error.message}`,
+        {
+          exit: 1, // oclif recommends exiting with a non-zero code on error
+          suggestions: [
+            'Check the console output for more details from the updateAndCleanStats script.',
+            "Ensure that the scan data directory (typically 'store') contains valid JSON files.",
+            "Verify file permissions for reading scan data and writing to the 'api' directory.",
+          ],
+        },
+      );
       // For more detailed debugging, you might want to log the full stack trace
       // console.error('Full error stack:', error.stack);
     }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -10,21 +10,21 @@
  * Contains details about its global variable name, version, and loaded modules.
  */
 export interface PrebidInstance {
-    /**
-     * The global variable name under which the Prebid.js instance is available.
-     * @example "pbjs"
-     */
-    globalVarName: string;
-    /**
-     * The version string of the Prebid.js instance.
-     * @example "7.53.0"
-     */
-    version: string;
-    /**
-     * An array of strings, where each string is the name of an installed Prebid.js module.
-     * @example ["consentManagement", "gptPreAuction", "dfpAdServerVideo"]
-     */
-    modules: string[];
+  /**
+   * The global variable name under which the Prebid.js instance is available.
+   * @example "pbjs"
+   */
+  globalVarName: string;
+  /**
+   * The version string of the Prebid.js instance.
+   * @example "7.53.0"
+   */
+  version: string;
+  /**
+   * An array of strings, where each string is the name of an installed Prebid.js module.
+   * @example ["consentManagement", "gptPreAuction", "dfpAdServerVideo"]
+   */
+  modules: string[];
 }
 
 /**
@@ -42,26 +42,26 @@ export interface PrebidInstance {
  * };
  */
 export interface PageData {
-    /**
-     * An array of strings identifying ad libraries detected on the page.
-     * @example ["googletag", "apstag", "ats"]
-     */
-    libraries: string[];
-    /**
-     * The date the page was scanned, formatted as YYYY-MM-DD.
-     * @example "2023-10-26"
-     */
-    date: string;
-    /**
-     * An optional array of {@link PrebidInstance} objects, representing each
-     * Prebid.js instance found on the page. Undefined if no instances are found.
-     */
-    prebidInstances?: PrebidInstance[];
-    /**
-     * The URL of the page from which the data was extracted.
-     * @example "https://www.example.com/article"
-     */
-    url?: string;
+  /**
+   * An array of strings identifying ad libraries detected on the page.
+   * @example ["googletag", "apstag", "ats"]
+   */
+  libraries: string[];
+  /**
+   * The date the page was scanned, formatted as YYYY-MM-DD.
+   * @example "2023-10-26"
+   */
+  date: string;
+  /**
+   * An optional array of {@link PrebidInstance} objects, representing each
+   * Prebid.js instance found on the page. Undefined if no instances are found.
+   */
+  prebidInstances?: PrebidInstance[];
+  /**
+   * The URL of the page from which the data was extracted.
+   * @example "https://www.example.com/article"
+   */
+  url?: string;
 }
 
 /**
@@ -77,10 +77,10 @@ export type TaskResultType = 'success' | 'no_data' | 'error';
  * Contains the extracted {@link PageData}.
  */
 export interface TaskResultSuccess {
-    /** Identifies the result type as successful. */
-    type: 'success';
-    /** The {@link PageData} extracted from the page. */
-    data: PageData;
+  /** Identifies the result type as successful. */
+  type: 'success';
+  /** The {@link PageData} extracted from the page. */
+  data: PageData;
 }
 
 /**
@@ -88,25 +88,25 @@ export interface TaskResultSuccess {
  * advertising technology data (like Prebid.js) was detected.
  */
 export interface TaskResultNoData {
-    /** Identifies the result type as finding no relevant data. */
-    type: 'no_data';
-    /** The URL of the page that was processed. */
-    url: string;
+  /** Identifies the result type as finding no relevant data. */
+  type: 'no_data';
+  /** The URL of the page that was processed. */
+  url: string;
 }
 
 /**
  * Represents an outcome where an error occurred while attempting to process a page.
  */
 export interface TaskResultError {
-    /** Identifies the result type as an error. */
-    type: 'error';
-    /** The URL of the page that was being processed when the error occurred. */
-    url: string;
-    /**
-     * A string code or message describing the error.
-     * @example "NET_TIMEOUT", "PBJS_NOT_FOUND"
-     */
-    error: string;
+  /** Identifies the result type as an error. */
+  type: 'error';
+  /** The URL of the page that was being processed when the error occurred. */
+  url: string;
+  /**
+   * A string code or message describing the error.
+   * @example "NET_TIMEOUT", "PBJS_NOT_FOUND"
+   */
+  error: string;
 }
 
 /**

--- a/src/config/stats-config.ts
+++ b/src/config/stats-config.ts
@@ -24,7 +24,11 @@ export const OUTPUT_DIR: string = path.join(PROJECT_ROOT, 'store');
  * @description The full path to the output JSON file (`api.json`) that contains the aggregated statistics.
  * Resolved relative to the project root.
  */
-export const FINAL_API_FILE_PATH: string = path.join(PROJECT_ROOT, 'api', 'api.json');
+export const FINAL_API_FILE_PATH: string = path.join(
+  PROJECT_ROOT,
+  'api',
+  'api.json',
+);
 
 /**
  * @const {number} MIN_COUNT_THRESHOLD
@@ -51,9 +55,21 @@ export const MONTH_ABBR_REGEX: RegExp = /^[A-Z][a-z]{2}$/;
  * @property {function(string): boolean} rtdModule - Identifies Real-Time Data (RTD) modules.
  * @property {function(string): boolean} analyticsAdapter - Identifies analytics adapter modules.
  */
-export const DEFAULT_MODULE_CATEGORIES: { [key: string]: (name: string) => boolean } = {
+export const DEFAULT_MODULE_CATEGORIES: {
+  [key: string]: (name: string) => boolean;
+} = {
   bidAdapter: (name: string): boolean => name.includes('BidAdapter'),
-  idModule: (name: string): boolean => name.includes('IdSystem') || ['userId', 'idImportLibrary', 'pubCommonId', 'utiqSystem', 'trustpidSystem'].includes(name),
-  rtdModule: (name: string): boolean => name.includes('Rtd' + 'Provider') || name === 'rtdModule', // Forcing re-evaluation of 'RtdProvider'
-  analyticsAdapter: (name: string): boolean => name.includes('AnalyticsAdapter'),
+  idModule: (name: string): boolean =>
+    name.includes('IdSystem') ||
+    [
+      'userId',
+      'idImportLibrary',
+      'pubCommonId',
+      'utiqSystem',
+      'trustpidSystem',
+    ].includes(name),
+  rtdModule: (name: string): boolean =>
+    name.includes('Rtd' + 'Provider') || name === 'rtdModule', // Forcing re-evaluation of 'RtdProvider'
+  analyticsAdapter: (name: string): boolean =>
+    name.includes('AnalyticsAdapter'),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,9 @@ import loggerModule, { initializeLogger } from './utils/logger.js';
 initializeLogger('logs');
 const logger = loggerModule.instance;
 
-console.log('DEBUG: src/index.ts is being executed - this should not happen if oclif is the entry point.');
-logger.warn('src/index.ts executed - this might indicate an issue with entry point configuration. Oclif should use bin/run or bin/dev.');
+console.log(
+  'DEBUG: src/index.ts is being executed - this should not happen if oclif is the entry point.',
+);
+logger.warn(
+  'src/index.ts executed - this might indicate an issue with entry point configuration. Oclif should use bin/run or bin/dev.',
+);

--- a/src/prebid.ts
+++ b/src/prebid.ts
@@ -16,30 +16,36 @@ import * as fs from 'fs';
 import { initializeLogger } from './utils/logger.js';
 import type { Logger as WinstonLogger } from 'winston';
 import { addExtra } from 'puppeteer-extra';
-import puppeteerVanilla, { Browser, PuppeteerLaunchOptions, Page } from 'puppeteer';
+import puppeteerVanilla, {
+  Browser,
+  PuppeteerLaunchOptions,
+  Page,
+} from 'puppeteer';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
-import blockResourcesPluginFactory, { BlockResourcesPlugin } from 'puppeteer-extra-plugin-block-resources'; // Import type for plugin
+import blockResourcesPluginFactory, {
+  BlockResourcesPlugin,
+} from 'puppeteer-extra-plugin-block-resources'; // Import type for plugin
 import { Cluster } from 'puppeteer-cluster';
 
 // Import functions from new modules
 import {
-    processFileContent,
-    fetchUrlsFromGitHub,
-    loadFileContents
+  processFileContent,
+  fetchUrlsFromGitHub,
+  loadFileContents,
 } from './utils/url-loader.js';
 
 import {
-    processPageTask, // The core function for processing a single page
-    // TaskResult and PageData are now imported from common/types
+  processPageTask, // The core function for processing a single page
+  // TaskResult and PageData are now imported from common/types
 } from './utils/puppeteer-task.js';
 
 // Import shared types from the new common location
 import type { TaskResult, PageData } from '../common/types.js';
 
 import {
-    processAndLogTaskResults,
-    writeResultsToFile,
-    updateInputFile
+  processAndLogTaskResults,
+  writeResultsToFile,
+  updateInputFile,
 } from './utils/results-handler.js';
 
 /**
@@ -48,45 +54,45 @@ import {
  * including URL sources, Puppeteer settings, concurrency, and output.
  */
 export interface PrebidExplorerOptions {
-    /** Optional path to an input file containing URLs to scan (e.g., .txt, .json, .csv). */
-    inputFile?: string; // Make optional as it might not be needed if githubRepo is used
-    /** Optional path to a CSV file (currently unused, consider for future use or removal). */
-    csvFile?: string;
-    /** Optional URL of a GitHub repository or direct file link to fetch URLs from. */
-    githubRepo?: string;
-    /** Optional maximum number of URLs to process from the source. */
-    numUrls?: number;
-    /** The type of Puppeteer execution: 'vanilla' (single browser instance) or 'cluster' (multiple instances). */
-    puppeteerType: 'vanilla' | 'cluster';
-    /** The maximum number of concurrent Puppeteer instances/pages when using 'cluster' mode. */
-    concurrency: number;
-    /** Whether to run Puppeteer in headless mode. */
-    headless: boolean;
-    /** Whether to enable Puppeteer cluster monitoring (if 'cluster' mode is used). */
-    monitor: boolean;
-    /** The directory where output JSON files will be saved. */
-    /** The directory where output JSON files containing scan results will be saved. */
-    outputDir: string;
-    /** The directory where log files (e.g., activity logs, error logs) will be saved. */
-    logDir: string;
-    /**
-     * Optional Puppeteer launch options to customize browser instantiation.
-     * @see https://pptr.dev/api/puppeteer.puppeteerlaunchoptions
-     * @example { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
-     */
-    puppeteerLaunchOptions?: PuppeteerLaunchOptions;
-    /**
-     * Optional string specifying a range of URLs to process from the input list (1-based index).
-     * Useful for splitting large lists or resuming partial scans.
-     * @example "1-100", "50-", "-200"
-     */
-    range?: string;
-    /**
-     * Optional number of URLs to process in each batch or chunk.
-     * If set to 0 or undefined, all URLs are processed in a single batch (or per cluster limits).
-     * Useful for managing resources or if processing needs to be intermittent.
-     */
-    chunkSize?: number;
+  /** Optional path to an input file containing URLs to scan (e.g., .txt, .json, .csv). */
+  inputFile?: string; // Make optional as it might not be needed if githubRepo is used
+  /** Optional path to a CSV file (currently unused, consider for future use or removal). */
+  csvFile?: string;
+  /** Optional URL of a GitHub repository or direct file link to fetch URLs from. */
+  githubRepo?: string;
+  /** Optional maximum number of URLs to process from the source. */
+  numUrls?: number;
+  /** The type of Puppeteer execution: 'vanilla' (single browser instance) or 'cluster' (multiple instances). */
+  puppeteerType: 'vanilla' | 'cluster';
+  /** The maximum number of concurrent Puppeteer instances/pages when using 'cluster' mode. */
+  concurrency: number;
+  /** Whether to run Puppeteer in headless mode. */
+  headless: boolean;
+  /** Whether to enable Puppeteer cluster monitoring (if 'cluster' mode is used). */
+  monitor: boolean;
+  /** The directory where output JSON files will be saved. */
+  /** The directory where output JSON files containing scan results will be saved. */
+  outputDir: string;
+  /** The directory where log files (e.g., activity logs, error logs) will be saved. */
+  logDir: string;
+  /**
+   * Optional Puppeteer launch options to customize browser instantiation.
+   * @see https://pptr.dev/api/puppeteer.puppeteerlaunchoptions
+   * @example { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
+   */
+  puppeteerLaunchOptions?: PuppeteerLaunchOptions;
+  /**
+   * Optional string specifying a range of URLs to process from the input list (1-based index).
+   * Useful for splitting large lists or resuming partial scans.
+   * @example "1-100", "50-", "-200"
+   */
+  range?: string;
+  /**
+   * Optional number of URLs to process in each batch or chunk.
+   * If set to 0 or undefined, all URLs are processed in a single batch (or per cluster limits).
+   * Useful for managing resources or if processing needs to be intermittent.
+   */
+  chunkSize?: number;
 }
 
 let logger: WinstonLogger; // Global logger instance, initialized within prebidExplorer.
@@ -95,8 +101,9 @@ let logger: WinstonLogger; // Global logger instance, initialized within prebidE
 // The 'as any' and 'as unknown as typeof puppeteerVanilla' casts are a common way
 // to handle the dynamic nature of puppeteer-extra plugins while retaining type safety
 // for the core puppeteerVanilla methods.
-const puppeteer = addExtra(puppeteerVanilla as any) as unknown as typeof puppeteerVanilla;
-
+const puppeteer = addExtra(
+  puppeteerVanilla as any,
+) as unknown as typeof puppeteerVanilla;
 
 /**
  * The main entry point for the Prebid Explorer tool.
@@ -132,285 +139,396 @@ const puppeteer = addExtra(puppeteerVanilla as any) as unknown as typeof puppete
  *   .then(() => console.log("Prebid Explorer finished."))
  *   .catch(error => console.error("Prebid Explorer failed:", error));
  */
-export async function prebidExplorer(options: PrebidExplorerOptions): Promise<void> {
-    logger = initializeLogger(options.logDir); // Initialize the global logger
+export async function prebidExplorer(
+  options: PrebidExplorerOptions,
+): Promise<void> {
+  logger = initializeLogger(options.logDir); // Initialize the global logger
 
-    logger.info('Starting Prebid Explorer with options:', options);
+  logger.info('Starting Prebid Explorer with options:', options);
 
-    // Apply puppeteer-extra stealth plugin to help avoid bot detection
-    puppeteer.use(StealthPlugin());
+  // Apply puppeteer-extra stealth plugin to help avoid bot detection
+  puppeteer.use(StealthPlugin());
 
-    // Define specific type for blocked resource types for clarity
-    type ResourceType = 'image' | 'font' | 'websocket' | 'media' | 'texttrack' | 'eventsource' | 'manifest' | 'other' | 'stylesheet' | 'script' | 'xhr';
+  // Define specific type for blocked resource types for clarity
+  type ResourceType =
+    | 'image'
+    | 'font'
+    | 'websocket'
+    | 'media'
+    | 'texttrack'
+    | 'eventsource'
+    | 'manifest'
+    | 'other'
+    | 'stylesheet'
+    | 'script'
+    | 'xhr';
 
-    const resourcesToBlock: Set<ResourceType> = new Set<ResourceType>([
-        'image', 'font', 'media', // Common non-essential resources for ad tech scanning
-        'texttrack', 'eventsource', 'manifest', 'other'
-        // 'stylesheet', 'script', 'xhr', 'websocket' are usually essential and not blocked.
-    ]);
-    const blockResourcesPlugin = blockResourcesPluginFactory({ blockedTypes: resourcesToBlock });
-    puppeteer.use(blockResourcesPlugin);
-    logger.info(`Configured to block resource types: ${Array.from(resourcesToBlock).join(', ')}`);
+  const resourcesToBlock: Set<ResourceType> = new Set<ResourceType>([
+    'image',
+    'font',
+    'media', // Common non-essential resources for ad tech scanning
+    'texttrack',
+    'eventsource',
+    'manifest',
+    'other',
+    // 'stylesheet', 'script', 'xhr', 'websocket' are usually essential and not blocked.
+  ]);
+  const blockResourcesPlugin = blockResourcesPluginFactory({
+    blockedTypes: resourcesToBlock,
+  });
+  puppeteer.use(blockResourcesPlugin);
+  logger.info(
+    `Configured to block resource types: ${Array.from(resourcesToBlock).join(', ')}`,
+  );
 
-    const basePuppeteerOptions: PuppeteerLaunchOptions = {
-        protocolTimeout: 1000000, // Increased timeout for browser protocol communication.
-        defaultViewport: null, // Sets the viewport to null, effectively using the default viewport of the browser window.
-        headless: options.headless,
-        args: options.puppeteerLaunchOptions?.args || [],
-        ...(options.puppeteerLaunchOptions || {}) // Ensures options.puppeteerLaunchOptions is an object before spreading
-    };
+  const basePuppeteerOptions: PuppeteerLaunchOptions = {
+    protocolTimeout: 1000000, // Increased timeout for browser protocol communication.
+    defaultViewport: null, // Sets the viewport to null, effectively using the default viewport of the browser window.
+    headless: options.headless,
+    args: options.puppeteerLaunchOptions?.args || [],
+    ...(options.puppeteerLaunchOptions || {}), // Ensures options.puppeteerLaunchOptions is an object before spreading
+  };
 
-    // results array is correctly typed with PageData from puppeteer-task.ts
-    const taskResults: TaskResult[] = []; // Correctly typed with TaskResult from puppeteer-task.ts
-    /** @type {string[]} Array to store all URLs fetched from the specified source. */
-    let allUrls: string[] = [];
-    /** @type {Set<string>} Set to keep track of URLs that have been processed or are queued for processing. */
-    const processedUrls: Set<string> = new Set();
-    /** @type {string} String to identify the source of URLs (e.g., 'GitHub', 'InputFile'). */
-    let urlSourceType = ''; // To track the source for logging and file updates
+  // results array is correctly typed with PageData from puppeteer-task.ts
+  const taskResults: TaskResult[] = []; // Correctly typed with TaskResult from puppeteer-task.ts
+  /** @type {string[]} Array to store all URLs fetched from the specified source. */
+  let allUrls: string[] = [];
+  /** @type {Set<string>} Set to keep track of URLs that have been processed or are queued for processing. */
+  const processedUrls: Set<string> = new Set();
+  /** @type {string} String to identify the source of URLs (e.g., 'GitHub', 'InputFile'). */
+  let urlSourceType = ''; // To track the source for logging and file updates
 
-    // Determine the source of URLs (GitHub or local file) and fetch them.
-    if (options.githubRepo) {
-        urlSourceType = 'GitHub';
-        allUrls = await fetchUrlsFromGitHub(options.githubRepo, options.numUrls, logger);
-        if (allUrls.length > 0) {
-            logger.info(`Successfully loaded ${allUrls.length} URLs from GitHub repository: ${options.githubRepo}`);
-        } else {
-            logger.warn(`No URLs found or fetched from GitHub repository: ${options.githubRepo}.`);
-        }
-    } else if (options.inputFile) {
-        urlSourceType = 'InputFile';
-        const fileContent = loadFileContents(options.inputFile, logger);
-        if (fileContent) {
-            // Determine file type for logging, actual type handling is in processFileContent
-            const fileType = options.inputFile.substring(options.inputFile.lastIndexOf('.') + 1) || 'unknown';
-            logger.info(`Processing local file: ${options.inputFile} (detected type: ${fileType})`);
-            allUrls = await processFileContent(options.inputFile, fileContent, logger);
-            if (allUrls.length > 0) {
-                logger.info(`Successfully loaded ${allUrls.length} URLs from local ${fileType.toUpperCase()} file: ${options.inputFile}`);
-            } else {
-                logger.warn(`No URLs extracted from local ${fileType.toUpperCase()} file: ${options.inputFile}. Check file content and type handling.`);
-            }
-        } else {
-            // loadFileContents already logs the error, but we should ensure allUrls is empty and potentially throw
-            allUrls = []; // Ensure allUrls is empty if file read failed
-            logger.error(`Failed to load content from input file ${options.inputFile}. Cannot proceed with this source.`);
-            // Depending on desired behavior, you might want to throw an error here
-            // For now, it will proceed to the "No URLs to process" check.
-        }
+  // Determine the source of URLs (GitHub or local file) and fetch them.
+  if (options.githubRepo) {
+    urlSourceType = 'GitHub';
+    allUrls = await fetchUrlsFromGitHub(
+      options.githubRepo,
+      options.numUrls,
+      logger,
+    );
+    if (allUrls.length > 0) {
+      logger.info(
+        `Successfully loaded ${allUrls.length} URLs from GitHub repository: ${options.githubRepo}`,
+      );
     } else {
-        // This case should ideally be prevented by CLI validation in scan.ts
-        logger.error('No URL source provided. Either --githubRepo or inputFile argument must be specified.');
-        throw new Error('No URL source specified.');
+      logger.warn(
+        `No URLs found or fetched from GitHub repository: ${options.githubRepo}.`,
+      );
     }
-
-    // Exit if no URLs were found from the specified source.
-    if (allUrls.length === 0) {
-        logger.warn(`No URLs to process from ${urlSourceType || 'any specified source'}. Exiting.`);
-        return;
-    }
-    logger.info(`Initial total URLs found: ${allUrls.length}`, { firstFew: allUrls.slice(0, 5) });
-
-    // 1. URL Range Logic
-    // Apply URL range filtering if specified in options.
-    if (options.range) {
-        logger.info(`Applying range: ${options.range}`);
-        const originalUrlCount = allUrls.length;
-        let [startStr, endStr] = options.range.split('-');
-        let start = startStr ? parseInt(startStr, 10) : 1;
-        let end = endStr ? parseInt(endStr, 10) : allUrls.length;
-
-        if (isNaN(start) || isNaN(end) || start < 0 || end < 0) { // Allow start = 0 for internal 0-based, but user input is 1-based
-            logger.warn(`Invalid range format: "${options.range}". Proceeding with all URLs. Start and end must be numbers. User input is 1-based.`);
-        } else {
-            // Convert 1-based to 0-based indices
-            start = start > 0 ? start - 1 : 0; // If user enters 0 or negative, treat as start from beginning
-            end = end > 0 ? end : allUrls.length; // If user enters 0 or negative for end, or leaves it empty, treat as end of list
-
-            if (start >= allUrls.length) {
-                logger.warn(`Start of range (${start + 1}) is beyond the total number of URLs (${allUrls.length}). No URLs to process.`);
-                allUrls = [];
-            } else if (start > end -1) {
-                 logger.warn(`Start of range (${start + 1}) is greater than end of range (${end}). Proceeding with URLs from start to end of list.`);
-                 allUrls = allUrls.slice(start);
-            }
-            else {
-                allUrls = allUrls.slice(start, end); // end is exclusive for slice, matches 0-based end index
-                logger.info(`Applied range: Processing URLs from ${start + 1} to ${Math.min(end, originalUrlCount)} (0-based index ${start} to ${Math.min(end, originalUrlCount) -1}). Total URLs after range: ${allUrls.length} (out of ${originalUrlCount}).`);
-            }
-        }
-    }
-
-    if (allUrls.length === 0) {
-        logger.warn(`No URLs to process after applying range or due to empty initial list. Exiting.`);
-        return;
-    }
-    logger.info(`Total URLs to process after range check: ${allUrls.length}`, { firstFew: allUrls.slice(0, 5) });
-
-    /** @type {string[]} URLs to be processed after applying range and other filters. */
-    const urlsToProcess = allUrls; // This now contains potentially ranged URLs
-
-    // Define the core processing task (used by both vanilla and cluster)
-    // Note: The actual definition of processPageTask is now imported.
-    // We pass it to the cluster or call it directly, along with the logger.
-
-    // 2. Chunk Processing Logic
-    /** @type {number} Size of chunks for processing URLs. 0 means no chunking. */
-    const chunkSize = options.chunkSize && options.chunkSize > 0 ? options.chunkSize : 0;
-
-    // Process URLs in chunks if chunkSize is specified.
-    if (chunkSize > 0) {
-        logger.info(`Chunked processing enabled. Chunk size: ${chunkSize}`);
-        const totalChunks = Math.ceil(urlsToProcess.length / chunkSize);
-        logger.info(`Total chunks to process: ${totalChunks}`);
-
-        for (let i = 0; i < urlsToProcess.length; i += chunkSize) {
-            const currentChunkUrls = urlsToProcess.slice(i, i + chunkSize);
-            const chunkNumber = Math.floor(i / chunkSize) + 1;
-            logger.info(`Processing chunk ${chunkNumber} of ${totalChunks}: URLs ${i + 1}-${Math.min(i + chunkSize, urlsToProcess.length)}`);
-
-            // Process the current chunk using either 'cluster' or 'vanilla' Puppeteer mode.
-            if (options.puppeteerType === 'cluster') {
-                const cluster: Cluster<{url: string, logger: WinstonLogger}, TaskResult> = await Cluster.launch({
-                    concurrency: Cluster.CONCURRENCY_CONTEXT,
-                    maxConcurrency: options.concurrency,
-                    monitor: options.monitor,
-                    puppeteer,
-                    puppeteerOptions: basePuppeteerOptions,
-                });
-
-                // Register the imported processPageTask with the cluster
-                await cluster.task(processPageTask);
-
-                try {
-                    const chunkPromises = currentChunkUrls.filter(url => url).map(url => {
-                        processedUrls.add(url); // Add to global processedUrls as it's queued
-                        return cluster.queue({ url, logger }) // Pass url and logger
-                            // No specific .then or .catch here, as results are collected from settledChunkResults
-                            // Error handling for queueing itself might be needed if cluster.queue can throw directly
-                            // However, task errors are handled by processPageTask and returned as TaskResultError.
-                    });
-                    // Wait for all promises in the chunk to settle
-                    const settledChunkResults = await Promise.allSettled(chunkPromises);
-
-                    settledChunkResults.forEach(settledResult => {
-                        if (settledResult.status === 'fulfilled') {
-                            // Ensure that settledResult.value is not null or undefined before pushing
-                            if (settledResult.value) {
-                                taskResults.push(settledResult.value);
-                            } else {
-                                // This case might occur if a task somehow resolves with no value,
-                                // though processPageTask is expected to always return a TaskResult.
-                                logger.warn('A task from cluster.queue (chunked) fulfilled but with undefined/null value.', { settledResult });
-                            }
-                        } else if (settledResult.status === 'rejected') {
-                            // This typically means an error occurred before processPageTask could even run or return a TaskResultError
-                            // (e.g., an issue with Puppeteer itself or the cluster queue mechanism for that specific task).
-                            // It's important to log this, as it might not be captured by processPageTask's own error handling.
-                            logger.error(`A promise from cluster.queue (chunk ${chunkNumber}) was rejected. This is unexpected if processPageTask is robust.`, { reason: settledResult.reason });
-                            // Optionally, create a TaskResultError here if the URL can be reliably determined.
-                            // const urlFromRejectedPromise = ... (this might be tricky to get reliably from the settledResult.reason)
-                            // if (urlFromRejectedPromise) {
-                            //     taskResults.push({ type: 'error', url: urlFromRejectedPromise, error: 'PROMISE_REJECTED_IN_QUEUE' });
-                            // }
-                        }
-                    });
-                    await cluster.idle();
-                    await cluster.close();
-                } catch (error: any) {
-                    logger.error(`An error occurred during processing chunk ${chunkNumber} with puppeteer-cluster.`, { error });
-                    if (cluster && !cluster.isClosed()) await cluster.close(); // Ensure cluster is closed on error
-                }
-            } else { // 'vanilla' Puppeteer for the current chunk
-                let browser: Browser | null = null;
-                try {
-                    browser = await puppeteer.launch(basePuppeteerOptions);
-                    for (const url of currentChunkUrls) {
-                        if (url) {
-                            const page = await browser.newPage();
-                            // Call the imported processPageTask directly
-                            const result = await processPageTask({ page, data: { url, logger } });
-                            taskResults.push(result);
-                            await page.close();
-                            processedUrls.add(url); // Add to global processedUrls
-                        }
-                    }
-                } catch (error: any) {
-                    logger.error(`An error occurred during processing chunk ${chunkNumber} with vanilla Puppeteer.`, { error });
-                } finally {
-                    if (browser) await browser.close();
-                }
-            }
-            logger.info(`Finished processing chunk ${chunkNumber} of ${totalChunks}.`);
-        }
+  } else if (options.inputFile) {
+    urlSourceType = 'InputFile';
+    const fileContent = loadFileContents(options.inputFile, logger);
+    if (fileContent) {
+      // Determine file type for logging, actual type handling is in processFileContent
+      const fileType =
+        options.inputFile.substring(options.inputFile.lastIndexOf('.') + 1) ||
+        'unknown';
+      logger.info(
+        `Processing local file: ${options.inputFile} (detected type: ${fileType})`,
+      );
+      allUrls = await processFileContent(
+        options.inputFile,
+        fileContent,
+        logger,
+      );
+      if (allUrls.length > 0) {
+        logger.info(
+          `Successfully loaded ${allUrls.length} URLs from local ${fileType.toUpperCase()} file: ${options.inputFile}`,
+        );
+      } else {
+        logger.warn(
+          `No URLs extracted from local ${fileType.toUpperCase()} file: ${options.inputFile}. Check file content and type handling.`,
+        );
+      }
     } else {
-        // Process all URLs at once (no chunking)
-        logger.info(`Processing all ${urlsToProcess.length} URLs without chunking.`);
-        if (options.puppeteerType === 'cluster') {
-            const cluster: Cluster<{url: string, logger: WinstonLogger}, TaskResult> = await Cluster.launch({
-                concurrency: Cluster.CONCURRENCY_CONTEXT,
-                maxConcurrency: options.concurrency,
-                monitor: options.monitor,
-                puppeteer,
-                puppeteerOptions: basePuppeteerOptions,
+      // loadFileContents already logs the error, but we should ensure allUrls is empty and potentially throw
+      allUrls = []; // Ensure allUrls is empty if file read failed
+      logger.error(
+        `Failed to load content from input file ${options.inputFile}. Cannot proceed with this source.`,
+      );
+      // Depending on desired behavior, you might want to throw an error here
+      // For now, it will proceed to the "No URLs to process" check.
+    }
+  } else {
+    // This case should ideally be prevented by CLI validation in scan.ts
+    logger.error(
+      'No URL source provided. Either --githubRepo or inputFile argument must be specified.',
+    );
+    throw new Error('No URL source specified.');
+  }
+
+  // Exit if no URLs were found from the specified source.
+  if (allUrls.length === 0) {
+    logger.warn(
+      `No URLs to process from ${urlSourceType || 'any specified source'}. Exiting.`,
+    );
+    return;
+  }
+  logger.info(`Initial total URLs found: ${allUrls.length}`, {
+    firstFew: allUrls.slice(0, 5),
+  });
+
+  // 1. URL Range Logic
+  // Apply URL range filtering if specified in options.
+  if (options.range) {
+    logger.info(`Applying range: ${options.range}`);
+    const originalUrlCount = allUrls.length;
+    let [startStr, endStr] = options.range.split('-');
+    let start = startStr ? parseInt(startStr, 10) : 1;
+    let end = endStr ? parseInt(endStr, 10) : allUrls.length;
+
+    if (isNaN(start) || isNaN(end) || start < 0 || end < 0) {
+      // Allow start = 0 for internal 0-based, but user input is 1-based
+      logger.warn(
+        `Invalid range format: "${options.range}". Proceeding with all URLs. Start and end must be numbers. User input is 1-based.`,
+      );
+    } else {
+      // Convert 1-based to 0-based indices
+      start = start > 0 ? start - 1 : 0; // If user enters 0 or negative, treat as start from beginning
+      end = end > 0 ? end : allUrls.length; // If user enters 0 or negative for end, or leaves it empty, treat as end of list
+
+      if (start >= allUrls.length) {
+        logger.warn(
+          `Start of range (${start + 1}) is beyond the total number of URLs (${allUrls.length}). No URLs to process.`,
+        );
+        allUrls = [];
+      } else if (start > end - 1) {
+        logger.warn(
+          `Start of range (${start + 1}) is greater than end of range (${end}). Proceeding with URLs from start to end of list.`,
+        );
+        allUrls = allUrls.slice(start);
+      } else {
+        allUrls = allUrls.slice(start, end); // end is exclusive for slice, matches 0-based end index
+        logger.info(
+          `Applied range: Processing URLs from ${start + 1} to ${Math.min(end, originalUrlCount)} (0-based index ${start} to ${Math.min(end, originalUrlCount) - 1}). Total URLs after range: ${allUrls.length} (out of ${originalUrlCount}).`,
+        );
+      }
+    }
+  }
+
+  if (allUrls.length === 0) {
+    logger.warn(
+      `No URLs to process after applying range or due to empty initial list. Exiting.`,
+    );
+    return;
+  }
+  logger.info(`Total URLs to process after range check: ${allUrls.length}`, {
+    firstFew: allUrls.slice(0, 5),
+  });
+
+  /** @type {string[]} URLs to be processed after applying range and other filters. */
+  const urlsToProcess = allUrls; // This now contains potentially ranged URLs
+
+  // Define the core processing task (used by both vanilla and cluster)
+  // Note: The actual definition of processPageTask is now imported.
+  // We pass it to the cluster or call it directly, along with the logger.
+
+  // 2. Chunk Processing Logic
+  /** @type {number} Size of chunks for processing URLs. 0 means no chunking. */
+  const chunkSize =
+    options.chunkSize && options.chunkSize > 0 ? options.chunkSize : 0;
+
+  // Process URLs in chunks if chunkSize is specified.
+  if (chunkSize > 0) {
+    logger.info(`Chunked processing enabled. Chunk size: ${chunkSize}`);
+    const totalChunks = Math.ceil(urlsToProcess.length / chunkSize);
+    logger.info(`Total chunks to process: ${totalChunks}`);
+
+    for (let i = 0; i < urlsToProcess.length; i += chunkSize) {
+      const currentChunkUrls = urlsToProcess.slice(i, i + chunkSize);
+      const chunkNumber = Math.floor(i / chunkSize) + 1;
+      logger.info(
+        `Processing chunk ${chunkNumber} of ${totalChunks}: URLs ${i + 1}-${Math.min(i + chunkSize, urlsToProcess.length)}`,
+      );
+
+      // Process the current chunk using either 'cluster' or 'vanilla' Puppeteer mode.
+      if (options.puppeteerType === 'cluster') {
+        const cluster: Cluster<
+          { url: string; logger: WinstonLogger },
+          TaskResult
+        > = await Cluster.launch({
+          concurrency: Cluster.CONCURRENCY_CONTEXT,
+          maxConcurrency: options.concurrency,
+          monitor: options.monitor,
+          puppeteer,
+          puppeteerOptions: basePuppeteerOptions,
+        });
+
+        // Register the imported processPageTask with the cluster
+        await cluster.task(processPageTask);
+
+        try {
+          const chunkPromises = currentChunkUrls
+            .filter((url) => url)
+            .map((url) => {
+              processedUrls.add(url); // Add to global processedUrls as it's queued
+              return cluster.queue({ url, logger }); // Pass url and logger
+              // No specific .then or .catch here, as results are collected from settledChunkResults
+              // Error handling for queueing itself might be needed if cluster.queue can throw directly
+              // However, task errors are handled by processPageTask and returned as TaskResultError.
             });
+          // Wait for all promises in the chunk to settle
+          const settledChunkResults = await Promise.allSettled(chunkPromises);
 
-            await cluster.task(processPageTask);
-
-            try {
-                const promises = urlsToProcess.filter(url => url).map(url => {
-                    processedUrls.add(url);
-                    return cluster.queue({ url, logger });
-                });
-                const settledResults = await Promise.allSettled(promises);
-                settledResults.forEach(settledResult => {
-                    if (settledResult.status === 'fulfilled') {
-                        if (settledResult.value) {
-                            taskResults.push(settledResult.value);
-                        } else {
-                             logger.warn('A task from cluster.queue (non-chunked) fulfilled but with undefined/null value.', { settledResult });
-                        }
-                    } else if (settledResult.status === 'rejected') {
-                        logger.error('A promise from cluster.queue (non-chunked) was rejected. This is unexpected if processPageTask is robust.', { reason: settledResult.reason });
-                        // Optionally, create a TaskResultError here
-                        // const urlFromRejectedPromise = ...
-                        // if (urlFromRejectedPromise) {
-                        //     taskResults.push({ type: 'error', url: urlFromRejectedPromise, error: 'PROMISE_REJECTED_IN_QUEUE' });
-                        // }
-                    }
-                });
-                await cluster.idle();
-                await cluster.close();
-            } catch (error: any) {
-                logger.error("An unexpected error occurred during cluster processing orchestration", { error });
-                if (cluster && !cluster.isClosed()) await cluster.close();
+          settledChunkResults.forEach((settledResult) => {
+            if (settledResult.status === 'fulfilled') {
+              // Ensure that settledResult.value is not null or undefined before pushing
+              if (settledResult.value) {
+                taskResults.push(settledResult.value);
+              } else {
+                // This case might occur if a task somehow resolves with no value,
+                // though processPageTask is expected to always return a TaskResult.
+                logger.warn(
+                  'A task from cluster.queue (chunked) fulfilled but with undefined/null value.',
+                  { settledResult },
+                );
+              }
+            } else if (settledResult.status === 'rejected') {
+              // This typically means an error occurred before processPageTask could even run or return a TaskResultError
+              // (e.g., an issue with Puppeteer itself or the cluster queue mechanism for that specific task).
+              // It's important to log this, as it might not be captured by processPageTask's own error handling.
+              logger.error(
+                `A promise from cluster.queue (chunk ${chunkNumber}) was rejected. This is unexpected if processPageTask is robust.`,
+                { reason: settledResult.reason },
+              );
+              // Optionally, create a TaskResultError here if the URL can be reliably determined.
+              // const urlFromRejectedPromise = ... (this might be tricky to get reliably from the settledResult.reason)
+              // if (urlFromRejectedPromise) {
+              //     taskResults.push({ type: 'error', url: urlFromRejectedPromise, error: 'PROMISE_REJECTED_IN_QUEUE' });
+              // }
             }
-        } else { // 'vanilla' Puppeteer
-            let browser: Browser | null = null;
-            try {
-                browser = await puppeteer.launch(basePuppeteerOptions);
-                for (const url of urlsToProcess) {
-                    if (url) {
-                        const page = await browser.newPage();
-                        const result = await processPageTask({ page, data: { url, logger } });
-                        taskResults.push(result);
-                        await page.close();
-                        processedUrls.add(url);
-                    }
-                }
-            } catch (error: any) {
-                logger.error("An unexpected error occurred during vanilla Puppeteer processing", { error });
-            } finally {
-                if (browser) await browser.close();
-            }
+          });
+          await cluster.idle();
+          await cluster.close();
+        } catch (error: any) {
+          logger.error(
+            `An error occurred during processing chunk ${chunkNumber} with puppeteer-cluster.`,
+            { error },
+          );
+          if (cluster && !cluster.isClosed()) await cluster.close(); // Ensure cluster is closed on error
         }
+      } else {
+        // 'vanilla' Puppeteer for the current chunk
+        let browser: Browser | null = null;
+        try {
+          browser = await puppeteer.launch(basePuppeteerOptions);
+          for (const url of currentChunkUrls) {
+            if (url) {
+              const page = await browser.newPage();
+              // Call the imported processPageTask directly
+              const result = await processPageTask({
+                page,
+                data: { url, logger },
+              });
+              taskResults.push(result);
+              await page.close();
+              processedUrls.add(url); // Add to global processedUrls
+            }
+          }
+        } catch (error: any) {
+          logger.error(
+            `An error occurred during processing chunk ${chunkNumber} with vanilla Puppeteer.`,
+            { error },
+          );
+        } finally {
+          if (browser) await browser.close();
+        }
+      }
+      logger.info(
+        `Finished processing chunk ${chunkNumber} of ${totalChunks}.`,
+      );
     }
+  } else {
+    // Process all URLs at once (no chunking)
+    logger.info(
+      `Processing all ${urlsToProcess.length} URLs without chunking.`,
+    );
+    if (options.puppeteerType === 'cluster') {
+      const cluster: Cluster<
+        { url: string; logger: WinstonLogger },
+        TaskResult
+      > = await Cluster.launch({
+        concurrency: Cluster.CONCURRENCY_CONTEXT,
+        maxConcurrency: options.concurrency,
+        monitor: options.monitor,
+        puppeteer,
+        puppeteerOptions: basePuppeteerOptions,
+      });
 
-    // Use functions from results-handler.ts
-    const successfulResults = processAndLogTaskResults(taskResults, logger);
-    writeResultsToFile(successfulResults, options.outputDir, logger);
+      await cluster.task(processPageTask);
 
-    if (urlSourceType === 'InputFile' && options.inputFile) {
-        updateInputFile(options.inputFile, urlsToProcess, taskResults, logger);
+      try {
+        const promises = urlsToProcess
+          .filter((url) => url)
+          .map((url) => {
+            processedUrls.add(url);
+            return cluster.queue({ url, logger });
+          });
+        const settledResults = await Promise.allSettled(promises);
+        settledResults.forEach((settledResult) => {
+          if (settledResult.status === 'fulfilled') {
+            if (settledResult.value) {
+              taskResults.push(settledResult.value);
+            } else {
+              logger.warn(
+                'A task from cluster.queue (non-chunked) fulfilled but with undefined/null value.',
+                { settledResult },
+              );
+            }
+          } else if (settledResult.status === 'rejected') {
+            logger.error(
+              'A promise from cluster.queue (non-chunked) was rejected. This is unexpected if processPageTask is robust.',
+              { reason: settledResult.reason },
+            );
+            // Optionally, create a TaskResultError here
+            // const urlFromRejectedPromise = ...
+            // if (urlFromRejectedPromise) {
+            //     taskResults.push({ type: 'error', url: urlFromRejectedPromise, error: 'PROMISE_REJECTED_IN_QUEUE' });
+            // }
+          }
+        });
+        await cluster.idle();
+        await cluster.close();
+      } catch (error: any) {
+        logger.error(
+          'An unexpected error occurred during cluster processing orchestration',
+          { error },
+        );
+        if (cluster && !cluster.isClosed()) await cluster.close();
+      }
+    } else {
+      // 'vanilla' Puppeteer
+      let browser: Browser | null = null;
+      try {
+        browser = await puppeteer.launch(basePuppeteerOptions);
+        for (const url of urlsToProcess) {
+          if (url) {
+            const page = await browser.newPage();
+            const result = await processPageTask({
+              page,
+              data: { url, logger },
+            });
+            taskResults.push(result);
+            await page.close();
+            processedUrls.add(url);
+          }
+        }
+      } catch (error: any) {
+        logger.error(
+          'An unexpected error occurred during vanilla Puppeteer processing',
+          { error },
+        );
+      } finally {
+        if (browser) await browser.close();
+      }
     }
+  }
+
+  // Use functions from results-handler.ts
+  const successfulResults = processAndLogTaskResults(taskResults, logger);
+  writeResultsToFile(successfulResults, options.outputDir, logger);
+
+  if (urlSourceType === 'InputFile' && options.inputFile) {
+    updateInputFile(options.inputFile, urlsToProcess, taskResults, logger);
+  }
 }

--- a/src/services/monitoring-service.ts
+++ b/src/services/monitoring-service.ts
@@ -9,32 +9,46 @@ import type { Logger as WinstonLogger } from 'winston';
  */
 export async function executeMonitoringLogic(
   logger: WinstonLogger,
-  oclifLogger: (message?: string | undefined, ...args: any[]) => void
+  oclifLogger: (message?: string | undefined, ...args: any[]) => void,
 ): Promise<void> {
   const tracer = trace.getTracer('prebid-integration-monitor-tracer');
 
-  await tracer.startActiveSpan('application-main-span', async (parentSpan: Span) => {
-    logger.info('Inside parent span (monitoring_service).');
-    oclifLogger('Inside parent span (monitoring_service).');
+  await tracer.startActiveSpan(
+    'application-main-span',
+    async (parentSpan: Span) => {
+      logger.info('Inside parent span (monitoring_service).');
+      oclifLogger('Inside parent span (monitoring_service).');
 
-    await tracer.startActiveSpan('child-task-span', async (childSpan: Span) => {
-      logger.info('Inside child span, performing a task (monitoring_service)...');
-      oclifLogger('Inside child span, performing a task (monitoring_service)...');
-      childSpan.addEvent('Task processing started');
+      await tracer.startActiveSpan(
+        'child-task-span',
+        async (childSpan: Span) => {
+          logger.info(
+            'Inside child span, performing a task (monitoring_service)...',
+          );
+          oclifLogger(
+            'Inside child span, performing a task (monitoring_service)...',
+          );
+          childSpan.addEvent('Task processing started');
 
-      // Simulate some work
-      await new Promise(resolve => setTimeout(resolve, 100)); // 100ms delay
+          // Simulate some work
+          await new Promise((resolve) => setTimeout(resolve, 100)); // 100ms delay
 
-      childSpan.addEvent('Task processing finished');
-      logger.info('Child span task complete (monitoring_service).');
-      oclifLogger('Child span task complete (monitoring_service).');
-      childSpan.end();
-    });
+          childSpan.addEvent('Task processing finished');
+          logger.info('Child span task complete (monitoring_service).');
+          oclifLogger('Child span task complete (monitoring_service).');
+          childSpan.end();
+        },
+      );
 
-    logger.info('Parent span continuing after child span (monitoring_service).');
-    oclifLogger('Parent span continuing after child span (monitoring_service).');
-    parentSpan.end();
-  });
+      logger.info(
+        'Parent span continuing after child span (monitoring_service).',
+      );
+      oclifLogger(
+        'Parent span continuing after child span (monitoring_service).',
+      );
+      parentSpan.end();
+    },
+  );
 
   logger.info('Main application processing finished (monitoring_service).');
   oclifLogger('Main application processing finished (monitoring_service).');

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -7,7 +7,10 @@
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { ConsoleSpanExporter, BatchSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import {
+  ConsoleSpanExporter,
+  BatchSpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
 // Resource identifies the entity producing telemetry (e.g., a service).
 // It's recommended to configure it with attributes like service name, version, environment, etc.
 // Example: new Resource({ [SemanticResourceAttributes.SERVICE_NAME]: 'your-service-name', [SemanticResourceAttributes.SERVICE_VERSION]: '1.0.0' })
@@ -30,7 +33,8 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 const _createServiceResource = (): Resource => {
   const serviceName = process.env.OTEL_SERVICE_NAME || 'unknown_service';
   const serviceVersion = process.env.OTEL_SERVICE_VERSION || '0.0.0';
-  const deploymentEnvironment = process.env.OTEL_DEPLOYMENT_ENVIRONMENT || 'unknown';
+  const deploymentEnvironment =
+    process.env.OTEL_DEPLOYMENT_ENVIRONMENT || 'unknown';
 
   return new Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
@@ -98,8 +102,8 @@ export const initTracer = () => {
       // Advanced configuration options include scheduledDelayMillis, maxQueueSize, maxExportBatchSize etc.
       // See OpenTelemetry documentation for more details on BatchSpanProcessor configuration.
       spanProcessors: [
-          new BatchSpanProcessor(consoleExporter), // For local debugging
-          new BatchSpanProcessor(otlpExporter)     // For production export
+        new BatchSpanProcessor(consoleExporter), // For local debugging
+        new BatchSpanProcessor(otlpExporter), // For production export
       ],
       // Enables a suite of automatic instrumentations for common Node.js libraries
       // (e.g., HTTP, Express, gRPC, various DB clients like pg, mysql).
@@ -109,10 +113,11 @@ export const initTracer = () => {
       instrumentations: [getNodeAutoInstrumentations()],
     });
 
-    console.log('OpenTelemetry NodeSDK initialized with OTLP and Console exporters. Auto-instrumentations are enabled. Attempting to start SDK...');
+    console.log(
+      'OpenTelemetry NodeSDK initialized with OTLP and Console exporters. Auto-instrumentations are enabled. Attempting to start SDK...',
+    );
     sdk.start();
     console.log('OpenTelemetry NodeSDK started successfully.');
-
   } catch (error) {
     console.error('Failed to initialize or start OpenTelemetry SDK:', error);
     // Depending on the application's criticality of tracing, you might choose to:
@@ -135,7 +140,8 @@ export const initTracer = () => {
  */
 process.on('SIGTERM', () => {
   if (sdk) {
-    sdk.shutdown()
+    sdk
+      .shutdown()
       .then(() => console.log('Tracing terminated gracefully'))
       .catch((error) => console.error('Error shutting down tracing', error))
       .finally(() => process.exit(0));

--- a/src/utils/__tests__/file-system-utils.test.ts
+++ b/src/utils/__tests__/file-system-utils.test.ts
@@ -1,8 +1,8 @@
 import {
-    readJsonFile,
-    writeJsonFile,
-    ensureDirectoryExists,
-    readDirectory,
+  readJsonFile,
+  writeJsonFile,
+  ensureDirectoryExists,
+  readDirectory,
 } from '../file-system-utils'; // .js extension resolved by Jest
 import { Dirent, promises as fsPromises } from 'fs'; // Import Dirent directly for instanceof checks if needed
 import { vi, describe, it, expect, beforeEach } from 'vitest';
@@ -10,143 +10,180 @@ import logger from '../logger.js';
 
 // Mock fs module
 vi.mock('fs', async (importOriginal) => {
-    const originalModule = await importOriginal() as typeof import('fs');
-    return {
-        ...originalModule, // Spread original exports
-        promises: { // Override promises property
-            readFile: vi.fn(),
-            writeFile: vi.fn(),
-            mkdir: vi.fn(),
-            readdir: vi.fn(),
-            access: vi.fn(), // Not used by SUT but good to have if fsPromises.access was called
-        },
-    };
+  const originalModule = (await importOriginal()) as typeof import('fs');
+  return {
+    ...originalModule, // Spread original exports
+    promises: {
+      // Override promises property
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+      readdir: vi.fn(),
+      access: vi.fn(), // Not used by SUT but good to have if fsPromises.access was called
+    },
+  };
 });
 
 // Mock logger
 vi.mock('../logger', () => ({
-    default: {
-        instance: {
-            debug: vi.fn(),
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        },
-    }
+  default: {
+    instance: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
 }));
 
 describe('file-system-utils', () => {
-    beforeEach(() => {
-        // Clear all mock instances and calls to ensure test isolation
-        vi.clearAllMocks();
+  beforeEach(() => {
+    // Clear all mock instances and calls to ensure test isolation
+    vi.clearAllMocks();
+  });
+
+  describe('readJsonFile', () => {
+    it('should parse valid JSON string from file', async () => {
+      const mockData = { key: 'value', count: 123 };
+      (fsPromises.readFile as vi.Mock).mockResolvedValue(
+        JSON.stringify(mockData),
+      );
+
+      const data = await readJsonFile<{ key: string; count: number }>(
+        'dummy/path.json',
+      );
+      expect(data).toEqual(mockData);
+      expect(fsPromises.readFile).toHaveBeenCalledWith(
+        'dummy/path.json',
+        'utf8',
+      );
     });
 
-    describe('readJsonFile', () => {
-        it('should parse valid JSON string from file', async () => {
-            const mockData = { key: 'value', count: 123 };
-            (fsPromises.readFile as vi.Mock).mockResolvedValue(JSON.stringify(mockData));
-
-            const data = await readJsonFile<{ key: string, count: number }>('dummy/path.json');
-            expect(data).toEqual(mockData);
-            expect(fsPromises.readFile).toHaveBeenCalledWith('dummy/path.json', 'utf8');
-        });
-
-        it('should throw error for invalid JSON string', async () => {
-            (fsPromises.readFile as vi.Mock).mockResolvedValue('invalid json');
-            await expect(readJsonFile('dummy/path.json')).rejects.toThrow();
-            expect(logger.instance.error).toHaveBeenCalled();
-        });
-
-        it('should propagate error if readFile fails', async () => {
-            const mockError = new Error('File not found');
-            (fsPromises.readFile as vi.Mock).mockRejectedValue(mockError);
-            await expect(readJsonFile('dummy/path.json')).rejects.toThrow('File not found');
-            expect(logger.instance.error).toHaveBeenCalledWith(expect.stringContaining('dummy/path.json'), expect.objectContaining({ errorMessage: 'File not found' }));
-        });
+    it('should throw error for invalid JSON string', async () => {
+      (fsPromises.readFile as vi.Mock).mockResolvedValue('invalid json');
+      await expect(readJsonFile('dummy/path.json')).rejects.toThrow();
+      expect(logger.instance.error).toHaveBeenCalled();
     });
 
-    describe('writeJsonFile', () => {
-        it('should call writeFile with stringified data', async () => {
-            const mockData = { test: 'data' };
-            (fsPromises.writeFile as vi.Mock).mockResolvedValue(undefined);
+    it('should propagate error if readFile fails', async () => {
+      const mockError = new Error('File not found');
+      (fsPromises.readFile as vi.Mock).mockRejectedValue(mockError);
+      await expect(readJsonFile('dummy/path.json')).rejects.toThrow(
+        'File not found',
+      );
+      expect(logger.instance.error).toHaveBeenCalledWith(
+        expect.stringContaining('dummy/path.json'),
+        expect.objectContaining({ errorMessage: 'File not found' }),
+      );
+    });
+  });
 
-            await writeJsonFile('output/path.json', mockData);
-            expect(fsPromises.writeFile).toHaveBeenCalledWith('output/path.json', JSON.stringify(mockData, null, 2), 'utf8');
-        });
+  describe('writeJsonFile', () => {
+    it('should call writeFile with stringified data', async () => {
+      const mockData = { test: 'data' };
+      (fsPromises.writeFile as vi.Mock).mockResolvedValue(undefined);
 
-        it('should propagate error if writeFile fails', async () => {
-            const mockError = new Error('Permission denied');
-            (fsPromises.writeFile as vi.Mock).mockRejectedValue(mockError);
-            await expect(writeJsonFile('output/path.json', {})).rejects.toThrow('Permission denied');
-            expect(logger.instance.error).toHaveBeenCalled();
-        });
-
-        it('should propagate error if JSON.stringify fails (e.g. circular structure)', async () => {
-            const circularObj: any = { a: 1 };
-            circularObj.b = circularObj; // Create circular reference
-
-            // No need to mock fsPromises.writeFile here, as stringify will throw first.
-            // The actual error is caught by the function's try-catch.
-            await expect(writeJsonFile('output/path.json', circularObj)).rejects.toThrow(TypeError); // Or specific error by Node
-            expect(logger.instance.error).toHaveBeenCalled();
-        });
+      await writeJsonFile('output/path.json', mockData);
+      expect(fsPromises.writeFile).toHaveBeenCalledWith(
+        'output/path.json',
+        JSON.stringify(mockData, null, 2),
+        'utf8',
+      );
     });
 
-    describe('ensureDirectoryExists', () => {
-        it('should call mkdir with recursive true', async () => {
-            (fsPromises.mkdir as vi.Mock).mockResolvedValue(undefined);
-            await ensureDirectoryExists('new/dir');
-            expect(fsPromises.mkdir).toHaveBeenCalledWith('new/dir', { recursive: true });
-        });
-
-        it('should propagate error if mkdir fails critically (and re-throws)', async () => {
-            const mockError = new Error('Something went wrong');
-            (fsPromises.mkdir as vi.Mock).mockRejectedValue(mockError);
-            await expect(ensureDirectoryExists('new/dir')).rejects.toThrow('Something went wrong');
-            expect(logger.instance.error).toHaveBeenCalled();
-        });
+    it('should propagate error if writeFile fails', async () => {
+      const mockError = new Error('Permission denied');
+      (fsPromises.writeFile as vi.Mock).mockRejectedValue(mockError);
+      await expect(writeJsonFile('output/path.json', {})).rejects.toThrow(
+        'Permission denied',
+      );
+      expect(logger.instance.error).toHaveBeenCalled();
     });
 
-    describe('readDirectory', () => {
-        it('should call readdir and return string array by default', async () => {
-            const mockFilenames = ['file1.txt', 'file2.js'];
-            (fsPromises.readdir as vi.Mock).mockResolvedValue(mockFilenames);
+    it('should propagate error if JSON.stringify fails (e.g. circular structure)', async () => {
+      const circularObj: any = { a: 1 };
+      circularObj.b = circularObj; // Create circular reference
 
-            const files = await readDirectory('some/path');
-            expect(files).toEqual(mockFilenames);
-            expect(fsPromises.readdir).toHaveBeenCalledWith('some/path');
-        });
-
-        it('should call readdir and return string array if withFileTypes is false', async () => {
-            const mockFilenames = ['fileA.txt', 'fileB.js'];
-            (fsPromises.readdir as vi.Mock).mockResolvedValue(mockFilenames);
-
-            const files = await readDirectory('some/path', { withFileTypes: false });
-            expect(files).toEqual(mockFilenames);
-            expect(fsPromises.readdir).toHaveBeenCalledWith('some/path');
-        });
-
-        it('should call readdir with withFileTypes true and return Dirent array', async () => {
-            // Simulate Dirent-like objects, actual Dirent constructor is not easily mockable here
-            const mockDirents = [
-                { name: 'file1.txt', isDirectory: () => false, isFile: () => true } as Dirent,
-                { name: 'subdir', isDirectory: () => true, isFile: () => false } as Dirent,
-            ];
-            (fsPromises.readdir as vi.Mock).mockResolvedValue(mockDirents);
-
-            const dirents = await readDirectory('some/path', { withFileTypes: true });
-            expect(dirents).toEqual(mockDirents);
-            expect(fsPromises.readdir).toHaveBeenCalledWith('some/path', { withFileTypes: true });
-            // Example check of Dirent properties (if needed)
-            expect(dirents[0].name).toBe('file1.txt');
-            expect(dirents[1].isDirectory()).toBe(true);
-        });
-
-        it('should propagate error if readdir fails', async () => {
-            const mockError = new Error('Directory not found');
-            (fsPromises.readdir as vi.Mock).mockRejectedValue(mockError);
-            await expect(readDirectory('some/path')).rejects.toThrow('Directory not found');
-            expect(logger.instance.error).toHaveBeenCalled();
-        });
+      // No need to mock fsPromises.writeFile here, as stringify will throw first.
+      // The actual error is caught by the function's try-catch.
+      await expect(
+        writeJsonFile('output/path.json', circularObj),
+      ).rejects.toThrow(TypeError); // Or specific error by Node
+      expect(logger.instance.error).toHaveBeenCalled();
     });
+  });
+
+  describe('ensureDirectoryExists', () => {
+    it('should call mkdir with recursive true', async () => {
+      (fsPromises.mkdir as vi.Mock).mockResolvedValue(undefined);
+      await ensureDirectoryExists('new/dir');
+      expect(fsPromises.mkdir).toHaveBeenCalledWith('new/dir', {
+        recursive: true,
+      });
+    });
+
+    it('should propagate error if mkdir fails critically (and re-throws)', async () => {
+      const mockError = new Error('Something went wrong');
+      (fsPromises.mkdir as vi.Mock).mockRejectedValue(mockError);
+      await expect(ensureDirectoryExists('new/dir')).rejects.toThrow(
+        'Something went wrong',
+      );
+      expect(logger.instance.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('readDirectory', () => {
+    it('should call readdir and return string array by default', async () => {
+      const mockFilenames = ['file1.txt', 'file2.js'];
+      (fsPromises.readdir as vi.Mock).mockResolvedValue(mockFilenames);
+
+      const files = await readDirectory('some/path');
+      expect(files).toEqual(mockFilenames);
+      expect(fsPromises.readdir).toHaveBeenCalledWith('some/path');
+    });
+
+    it('should call readdir and return string array if withFileTypes is false', async () => {
+      const mockFilenames = ['fileA.txt', 'fileB.js'];
+      (fsPromises.readdir as vi.Mock).mockResolvedValue(mockFilenames);
+
+      const files = await readDirectory('some/path', { withFileTypes: false });
+      expect(files).toEqual(mockFilenames);
+      expect(fsPromises.readdir).toHaveBeenCalledWith('some/path');
+    });
+
+    it('should call readdir with withFileTypes true and return Dirent array', async () => {
+      // Simulate Dirent-like objects, actual Dirent constructor is not easily mockable here
+      const mockDirents = [
+        {
+          name: 'file1.txt',
+          isDirectory: () => false,
+          isFile: () => true,
+        } as Dirent,
+        {
+          name: 'subdir',
+          isDirectory: () => true,
+          isFile: () => false,
+        } as Dirent,
+      ];
+      (fsPromises.readdir as vi.Mock).mockResolvedValue(mockDirents);
+
+      const dirents = await readDirectory('some/path', { withFileTypes: true });
+      expect(dirents).toEqual(mockDirents);
+      expect(fsPromises.readdir).toHaveBeenCalledWith('some/path', {
+        withFileTypes: true,
+      });
+      // Example check of Dirent properties (if needed)
+      expect(dirents[0].name).toBe('file1.txt');
+      expect(dirents[1].isDirectory()).toBe(true);
+    });
+
+    it('should propagate error if readdir fails', async () => {
+      const mockError = new Error('Directory not found');
+      (fsPromises.readdir as vi.Mock).mockRejectedValue(mockError);
+      await expect(readDirectory('some/path')).rejects.toThrow(
+        'Directory not found',
+      );
+      expect(logger.instance.error).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/utils/__tests__/stats-processing.test.ts
+++ b/src/utils/__tests__/stats-processing.test.ts
@@ -1,143 +1,209 @@
 import {
-    parseVersion,
-    compareVersions,
-    _categorizeModules,
-    // Import other functions if they get tests: processModuleWebsiteCounts, processModuleDistribution, processVersionDistribution
+  parseVersion,
+  compareVersions,
+  _categorizeModules,
+  // Import other functions if they get tests: processModuleWebsiteCounts, processModuleDistribution, processVersionDistribution
 } from '../stats-processing'; // .js extension will be resolved by Jest
-import type { VersionComponents, CategorizedModules, ModuleDistribution } from '../stats-processing';
+import type {
+  VersionComponents,
+  CategorizedModules,
+  ModuleDistribution,
+} from '../stats-processing';
 import { DEFAULT_MODULE_CATEGORIES } from '../../config/stats-config.js'; // Actual config for some tests
 import { vi, describe, it, expect } from 'vitest';
 import logger from '../logger.js';
 
 // Mock logger
 vi.mock('../logger', () => ({
-    default: {
-        instance: {
-            debug: vi.fn(),
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-        },
-    }
+  default: {
+    instance: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
 }));
 
 describe('stats-processing', () => {
-    describe('parseVersion', () => {
-        it('should parse valid version strings correctly', () => {
-            expect(parseVersion("1.2.3")).toEqual<VersionComponents>({ major: 1, minor: 2, patch: 3, preRelease: null });
-            expect(parseVersion("v4.5.6")).toEqual<VersionComponents>({ major: 4, minor: 5, patch: 6, preRelease: null });
-            expect(parseVersion("7.8.9-pre.1")).toEqual<VersionComponents>({ major: 7, minor: 8, patch: 9, preRelease: "pre.1" });
-            expect(parseVersion("v10.11.12-alpha-beta")).toEqual<VersionComponents>({ major: 10, minor: 11, patch: 12, preRelease: "alpha-beta" });
-        });
-
-        it('should handle undefined, null, and empty string inputs', () => {
-            expect(parseVersion(undefined)).toEqual<VersionComponents>({ major: 0, minor: 0, patch: 0, preRelease: "invalid" });
-            // Assuming null is treated like undefined by the function's logic path for !versionString
-            expect(parseVersion(null as any)).toEqual<VersionComponents>({ major: 0, minor: 0, patch: 0, preRelease: "invalid" });
-            expect(parseVersion("")).toEqual<VersionComponents>({ major: 0, minor: 0, patch: 0, preRelease: "invalid" });
-        });
-
-        it('should handle malformed version strings', () => {
-            expect(parseVersion("abc")).toEqual<VersionComponents>({ major: 0, minor: 0, patch: 0, preRelease: "abc" });
-            expect(parseVersion("1.2")).toEqual<VersionComponents>({ major: 0, minor: 0, patch: 0, preRelease: "1.2" });
-            expect(parseVersion("1.beta")).toEqual<VersionComponents>({ major: 0, minor: 0, patch: 0, preRelease: "1.beta" });
-            // Check logger was called for malformed strings (if they are not empty/null/undefined)
-            parseVersion("xyz"); // call it
-            expect(logger.instance.warn).toHaveBeenCalledWith(expect.stringContaining('"xyz"'));
-        });
+  describe('parseVersion', () => {
+    it('should parse valid version strings correctly', () => {
+      expect(parseVersion('1.2.3')).toEqual<VersionComponents>({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        preRelease: null,
+      });
+      expect(parseVersion('v4.5.6')).toEqual<VersionComponents>({
+        major: 4,
+        minor: 5,
+        patch: 6,
+        preRelease: null,
+      });
+      expect(parseVersion('7.8.9-pre.1')).toEqual<VersionComponents>({
+        major: 7,
+        minor: 8,
+        patch: 9,
+        preRelease: 'pre.1',
+      });
+      expect(parseVersion('v10.11.12-alpha-beta')).toEqual<VersionComponents>({
+        major: 10,
+        minor: 11,
+        patch: 12,
+        preRelease: 'alpha-beta',
+      });
     });
 
-    describe('compareVersions', () => {
-        // For Array.prototype.sort((a,b) => compareVersions(a,b)) to sort newest first:
-        // if a is newer than b, return < 0
-        // if b is newer than a, return > 0
-        // if equal, return 0
-        it('should correctly compare major versions', () => {
-            expect(compareVersions("2.0.0", "1.0.0")).toBeLessThan(0); // 2.0.0 is newer
-            expect(compareVersions("1.0.0", "2.0.0")).toBeGreaterThan(0); // 2.0.0 is newer
-        });
-
-        it('should correctly compare minor versions', () => {
-            expect(compareVersions("1.2.0", "1.1.0")).toBeLessThan(0); // 1.2.0 is newer
-            expect(compareVersions("1.1.0", "1.2.0")).toBeGreaterThan(0); // 1.2.0 is newer
-        });
-
-        it('should correctly compare patch versions', () => {
-            expect(compareVersions("1.1.2", "1.1.1")).toBeLessThan(0); // 1.1.2 is newer
-            expect(compareVersions("1.1.1", "1.1.2")).toBeGreaterThan(0); // 1.1.2 is newer
-        });
-
-        it('should correctly compare pre-release versions', () => {
-            expect(compareVersions("1.0.0", "1.0.0-pre")).toBeLessThan(0); // release is newer than pre-release
-            expect(compareVersions("1.0.0-pre", "1.0.0")).toBeGreaterThan(0);
-            expect(compareVersions("1.0.0-beta", "1.0.0-alpha")).toBeLessThan(0); // beta is newer than alpha
-            expect(compareVersions("1.0.0-alpha", "1.0.0-beta")).toBeGreaterThan(0);
-        });
-
-        it('should handle identical versions', () => {
-            expect(compareVersions("1.1.1", "1.1.1")).toBe(0);
-            expect(compareVersions("2.0.0-pre", "2.0.0-pre")).toBe(0);
-        });
-
-        it('should handle versions that parse to invalid/default components', () => {
-            // "invalid" vs "1.0.0" -> 1.0.0 is newer
-            expect(compareVersions("invalid", "1.0.0")).toBeGreaterThan(0);
-            // "1.0.0" vs "invalid" -> 1.0.0 is newer
-            expect(compareVersions("1.0.0", "invalid")).toBeLessThan(0);
-            // "invalid1" vs "invalid2" -> comparison of preRelease strings "invalid1" vs "invalid2"
-            expect(compareVersions("invalid1", "invalid2")).toBeGreaterThan(0); // "invalid2" > "invalid1" lexicographically
-        });
+    it('should handle undefined, null, and empty string inputs', () => {
+      expect(parseVersion(undefined)).toEqual<VersionComponents>({
+        major: 0,
+        minor: 0,
+        patch: 0,
+        preRelease: 'invalid',
+      });
+      // Assuming null is treated like undefined by the function's logic path for !versionString
+      expect(parseVersion(null as any)).toEqual<VersionComponents>({
+        major: 0,
+        minor: 0,
+        patch: 0,
+        preRelease: 'invalid',
+      });
+      expect(parseVersion('')).toEqual<VersionComponents>({
+        major: 0,
+        minor: 0,
+        patch: 0,
+        preRelease: 'invalid',
+      });
     });
 
-    describe('_categorizeModules', () => {
-        const minCountThreshold = 2;
-        const countExtractor = (count: number) => count;
-
-        // For this test, we use the actual DEFAULT_MODULE_CATEGORIES
-        // to ensure 'someOtherModule' correctly falls into the 'other' category.
-        it('should categorize modules correctly, respect threshold, and handle "other"', () => {
-            const dataSource: ModuleDistribution = {
-                "rubiconBidAdapter": 5,    // Matches bidAdapter
-                "appnexusBidAdapter": 1,   // Matches bidAdapter, but below threshold
-                "userId": 3,               // Matches idModule
-                "someRTDProvider": 4,      // Carefully retyped "someRTDProvider"
-                "someAnalyticsAdapter": 5, // Matches analyticsAdapter
-                "unknownUtilityModule": 6, // Should go to 'other'
-            };
-
-            const result = _categorizeModules(
-                dataSource,
-                minCountThreshold,
-                countExtractor,
-                DEFAULT_MODULE_CATEGORIES // Use the actual imported categories
-            );
-
-            expect(result.bidAdapter).toEqual({ "rubiconBidAdapter": 5 });
-            expect(result.idModule).toEqual({ "userId": 3 });
-            expect(result.rtdModule).toEqual({ "someRTDProvider": 4 });
-            expect(result.analyticsAdapter).toEqual({ "someAnalyticsAdapter": 5 });
-            expect(result.other).toEqual({ "unknownUtilityModule": 6 });
-            expect(result.bidAdapter["appnexusBidAdapter"]).toBeUndefined();
-        });
-
-        it('should place modules below threshold nowhere', () => {
-            const dataSource: ModuleDistribution = { "rubiconBidAdapter": 1 }; // Below threshold of 2
-            const result = _categorizeModules(dataSource, minCountThreshold, countExtractor, DEFAULT_MODULE_CATEGORIES);
-            expect(Object.keys(result.bidAdapter)).toHaveLength(0);
-            expect(Object.keys(result.idModule)).toHaveLength(0);
-            expect(Object.keys(result.rtdModule)).toHaveLength(0);
-            expect(Object.keys(result.analyticsAdapter)).toHaveLength(0);
-            expect(Object.keys(result.other)).toHaveLength(0);
-        });
-
-        it('should handle empty dataSource', () => {
-            const dataSource: ModuleDistribution = {};
-            const result = _categorizeModules(dataSource, minCountThreshold, countExtractor, DEFAULT_MODULE_CATEGORIES);
-            expect(Object.keys(result.bidAdapter)).toHaveLength(0);
-            expect(Object.keys(result.idModule)).toHaveLength(0);
-            expect(Object.keys(result.rtdModule)).toHaveLength(0);
-            expect(Object.keys(result.analyticsAdapter)).toHaveLength(0);
-            expect(Object.keys(result.other)).toHaveLength(0);
-        });
+    it('should handle malformed version strings', () => {
+      expect(parseVersion('abc')).toEqual<VersionComponents>({
+        major: 0,
+        minor: 0,
+        patch: 0,
+        preRelease: 'abc',
+      });
+      expect(parseVersion('1.2')).toEqual<VersionComponents>({
+        major: 0,
+        minor: 0,
+        patch: 0,
+        preRelease: '1.2',
+      });
+      expect(parseVersion('1.beta')).toEqual<VersionComponents>({
+        major: 0,
+        minor: 0,
+        patch: 0,
+        preRelease: '1.beta',
+      });
+      // Check logger was called for malformed strings (if they are not empty/null/undefined)
+      parseVersion('xyz'); // call it
+      expect(logger.instance.warn).toHaveBeenCalledWith(
+        expect.stringContaining('"xyz"'),
+      );
     });
+  });
+
+  describe('compareVersions', () => {
+    // For Array.prototype.sort((a,b) => compareVersions(a,b)) to sort newest first:
+    // if a is newer than b, return < 0
+    // if b is newer than a, return > 0
+    // if equal, return 0
+    it('should correctly compare major versions', () => {
+      expect(compareVersions('2.0.0', '1.0.0')).toBeLessThan(0); // 2.0.0 is newer
+      expect(compareVersions('1.0.0', '2.0.0')).toBeGreaterThan(0); // 2.0.0 is newer
+    });
+
+    it('should correctly compare minor versions', () => {
+      expect(compareVersions('1.2.0', '1.1.0')).toBeLessThan(0); // 1.2.0 is newer
+      expect(compareVersions('1.1.0', '1.2.0')).toBeGreaterThan(0); // 1.2.0 is newer
+    });
+
+    it('should correctly compare patch versions', () => {
+      expect(compareVersions('1.1.2', '1.1.1')).toBeLessThan(0); // 1.1.2 is newer
+      expect(compareVersions('1.1.1', '1.1.2')).toBeGreaterThan(0); // 1.1.2 is newer
+    });
+
+    it('should correctly compare pre-release versions', () => {
+      expect(compareVersions('1.0.0', '1.0.0-pre')).toBeLessThan(0); // release is newer than pre-release
+      expect(compareVersions('1.0.0-pre', '1.0.0')).toBeGreaterThan(0);
+      expect(compareVersions('1.0.0-beta', '1.0.0-alpha')).toBeLessThan(0); // beta is newer than alpha
+      expect(compareVersions('1.0.0-alpha', '1.0.0-beta')).toBeGreaterThan(0);
+    });
+
+    it('should handle identical versions', () => {
+      expect(compareVersions('1.1.1', '1.1.1')).toBe(0);
+      expect(compareVersions('2.0.0-pre', '2.0.0-pre')).toBe(0);
+    });
+
+    it('should handle versions that parse to invalid/default components', () => {
+      // "invalid" vs "1.0.0" -> 1.0.0 is newer
+      expect(compareVersions('invalid', '1.0.0')).toBeGreaterThan(0);
+      // "1.0.0" vs "invalid" -> 1.0.0 is newer
+      expect(compareVersions('1.0.0', 'invalid')).toBeLessThan(0);
+      // "invalid1" vs "invalid2" -> comparison of preRelease strings "invalid1" vs "invalid2"
+      expect(compareVersions('invalid1', 'invalid2')).toBeGreaterThan(0); // "invalid2" > "invalid1" lexicographically
+    });
+  });
+
+  describe('_categorizeModules', () => {
+    const minCountThreshold = 2;
+    const countExtractor = (count: number) => count;
+
+    // For this test, we use the actual DEFAULT_MODULE_CATEGORIES
+    // to ensure 'someOtherModule' correctly falls into the 'other' category.
+    it('should categorize modules correctly, respect threshold, and handle "other"', () => {
+      const dataSource: ModuleDistribution = {
+        rubiconBidAdapter: 5, // Matches bidAdapter
+        appnexusBidAdapter: 1, // Matches bidAdapter, but below threshold
+        userId: 3, // Matches idModule
+        someRTDProvider: 4, // Carefully retyped "someRTDProvider"
+        someAnalyticsAdapter: 5, // Matches analyticsAdapter
+        unknownUtilityModule: 6, // Should go to 'other'
+      };
+
+      const result = _categorizeModules(
+        dataSource,
+        minCountThreshold,
+        countExtractor,
+        DEFAULT_MODULE_CATEGORIES, // Use the actual imported categories
+      );
+
+      expect(result.bidAdapter).toEqual({ rubiconBidAdapter: 5 });
+      expect(result.idModule).toEqual({ userId: 3 });
+      expect(result.rtdModule).toEqual({ someRTDProvider: 4 });
+      expect(result.analyticsAdapter).toEqual({ someAnalyticsAdapter: 5 });
+      expect(result.other).toEqual({ unknownUtilityModule: 6 });
+      expect(result.bidAdapter['appnexusBidAdapter']).toBeUndefined();
+    });
+
+    it('should place modules below threshold nowhere', () => {
+      const dataSource: ModuleDistribution = { rubiconBidAdapter: 1 }; // Below threshold of 2
+      const result = _categorizeModules(
+        dataSource,
+        minCountThreshold,
+        countExtractor,
+        DEFAULT_MODULE_CATEGORIES,
+      );
+      expect(Object.keys(result.bidAdapter)).toHaveLength(0);
+      expect(Object.keys(result.idModule)).toHaveLength(0);
+      expect(Object.keys(result.rtdModule)).toHaveLength(0);
+      expect(Object.keys(result.analyticsAdapter)).toHaveLength(0);
+      expect(Object.keys(result.other)).toHaveLength(0);
+    });
+
+    it('should handle empty dataSource', () => {
+      const dataSource: ModuleDistribution = {};
+      const result = _categorizeModules(
+        dataSource,
+        minCountThreshold,
+        countExtractor,
+        DEFAULT_MODULE_CATEGORIES,
+      );
+      expect(Object.keys(result.bidAdapter)).toHaveLength(0);
+      expect(Object.keys(result.idModule)).toHaveLength(0);
+      expect(Object.keys(result.rtdModule)).toHaveLength(0);
+      expect(Object.keys(result.analyticsAdapter)).toHaveLength(0);
+      expect(Object.keys(result.other)).toHaveLength(0);
+    });
+  });
 });

--- a/src/utils/file-system-utils.ts
+++ b/src/utils/file-system-utils.ts
@@ -14,19 +14,19 @@ import logger from './logger.js'; // Assuming logger is accessible here
  * @throws Will log an error using `logger.instance` if `fsPromises.mkdir` fails for unexpected reasons.
  */
 export async function ensureDirectoryExists(dirPath: string): Promise<void> {
-    try {
-        await fsPromises.mkdir(dirPath, { recursive: true });
-    } catch (error: any) {
-        // Log the error.
-        logger.instance.error(`Error ensuring directory ${dirPath} exists:`, {
-            errorName: error.name,
-            errorMessage: error.message,
-            // stack: error.stack // Optionally log stack for more details
-        });
-        // Rethrow the error so the caller is aware that directory creation failed,
-        // as this is often a critical step.
-        throw error;
-    }
+  try {
+    await fsPromises.mkdir(dirPath, { recursive: true });
+  } catch (error: any) {
+    // Log the error.
+    logger.instance.error(`Error ensuring directory ${dirPath} exists:`, {
+      errorName: error.name,
+      errorMessage: error.message,
+      // stack: error.stack // Optionally log stack for more details
+    });
+    // Rethrow the error so the caller is aware that directory creation failed,
+    // as this is often a critical step.
+    throw error;
+  }
 }
 
 /**
@@ -51,22 +51,31 @@ export async function ensureDirectoryExists(dirPath: string): Promise<void> {
  *   console.log(`${dirents[0].name} is a directory.`);
  * }
  */
-export async function readDirectory(dirPath: string, options: { withFileTypes: true }): Promise<Dirent[]>;
-export async function readDirectory(dirPath: string, options?: { withFileTypes?: false }): Promise<string[]>;
-export async function readDirectory(dirPath: string, options?: { withFileTypes?: boolean }): Promise<string[] | Dirent[]> {
-    try {
-        if (options?.withFileTypes) {
-            return await fsPromises.readdir(dirPath, { withFileTypes: true });
-        } else {
-            return await fsPromises.readdir(dirPath);
-        }
-    } catch (error: any) {
-        logger.instance.error(`Error reading directory ${dirPath}:`, {
-            errorName: error.name,
-            errorMessage: error.message,
-        });
-        throw error; // Rethrow to allow caller to handle critical errors like EACCES or ENOENT
+export async function readDirectory(
+  dirPath: string,
+  options: { withFileTypes: true },
+): Promise<Dirent[]>;
+export async function readDirectory(
+  dirPath: string,
+  options?: { withFileTypes?: false },
+): Promise<string[]>;
+export async function readDirectory(
+  dirPath: string,
+  options?: { withFileTypes?: boolean },
+): Promise<string[] | Dirent[]> {
+  try {
+    if (options?.withFileTypes) {
+      return await fsPromises.readdir(dirPath, { withFileTypes: true });
+    } else {
+      return await fsPromises.readdir(dirPath);
     }
+  } catch (error: any) {
+    logger.instance.error(`Error reading directory ${dirPath}:`, {
+      errorName: error.name,
+      errorMessage: error.message,
+    });
+    throw error; // Rethrow to allow caller to handle critical errors like EACCES or ENOENT
+  }
 }
 
 /**
@@ -89,17 +98,17 @@ export async function readDirectory(dirPath: string, options?: { withFileTypes?:
  * }
  */
 export async function readJsonFile<T>(filePath: string): Promise<T> {
-    try {
-        const fileContent: string = await fsPromises.readFile(filePath, 'utf8');
-        return JSON.parse(fileContent) as T;
-    } catch (error: any) {
-        logger.instance.error(`Error reading or parsing JSON file ${filePath}:`, {
-            errorName: error.name,
-            errorMessage: error.message,
-            // stack: error.stack // Optional: for more detailed debugging
-        });
-        throw error; // Rethrow for the caller to handle
-    }
+  try {
+    const fileContent: string = await fsPromises.readFile(filePath, 'utf8');
+    return JSON.parse(fileContent) as T;
+  } catch (error: any) {
+    logger.instance.error(`Error reading or parsing JSON file ${filePath}:`, {
+      errorName: error.name,
+      errorMessage: error.message,
+      // stack: error.stack // Optional: for more detailed debugging
+    });
+    throw error; // Rethrow for the caller to handle
+  }
 }
 
 /**
@@ -119,15 +128,18 @@ export async function readJsonFile<T>(filePath: string): Promise<T> {
  *   // Handle file writing error
  * }
  */
-export async function writeJsonFile(filePath: string, data: any): Promise<void> {
-    try {
-        const jsonData: string = JSON.stringify(data, null, 2);
-        await fsPromises.writeFile(filePath, jsonData, 'utf8');
-    } catch (error: any) {
-        logger.instance.error(`Error writing JSON file ${filePath}:`, {
-            errorName: error.name,
-            errorMessage: error.message,
-        });
-        throw error; // Rethrow for the caller to handle
-    }
+export async function writeJsonFile(
+  filePath: string,
+  data: any,
+): Promise<void> {
+  try {
+    const jsonData: string = JSON.stringify(data, null, 2);
+    await fsPromises.writeFile(filePath, jsonData, 'utf8');
+  } catch (error: any) {
+    logger.instance.error(`Error writing JSON file ${filePath}:`, {
+      errorName: error.name,
+      errorMessage: error.message,
+    });
+    throw error; // Rethrow for the caller to handle
+  }
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -19,7 +19,7 @@ let logger: Logger;
  * @param {Logform.TransformableInfo} info - The log information object implicitly passed by Winston.
  * @returns {Logform.TransformableInfo} The modified log information object.
  */
-const openTelemetryFormat = winston.format(info => {
+const openTelemetryFormat = winston.format((info) => {
   const activeSpan = trace.getActiveSpan();
   if (activeSpan) {
     const spanContext = activeSpan.spanContext();
@@ -43,11 +43,13 @@ const openTelemetryFormat = winston.format(info => {
  */
 function formatSplatMetadata(splat: any): string {
   if (Array.isArray(splat)) {
-    const metadata = splat.map((s: any) => typeof s === 'object' ? JSON.stringify(s) : s).join(' ');
+    const metadata = splat
+      .map((s: any) => (typeof s === 'object' ? JSON.stringify(s) : s))
+      .join(' ');
     return metadata || ''; // Return empty string if metadata is empty after join
   } else if (typeof splat === 'object' && splat !== null) {
     const metadataString = JSON.stringify(splat);
-    return (metadataString && metadataString !== '{}') ? metadataString : '';
+    return metadataString && metadataString !== '{}' ? metadataString : '';
   } else if (splat !== undefined) {
     return String(splat);
   }
@@ -73,7 +75,11 @@ function formatConsoleLogMessage(info: Logform.TransformableInfo): string {
     }
   }
 
-  if (typeof info.message === 'string' && info.message.startsWith('Initial URLs read from') && typeof info.count === 'number') {
+  if (
+    typeof info.message === 'string' &&
+    info.message.startsWith('Initial URLs read from') &&
+    typeof info.count === 'number'
+  ) {
     message += ` count: ${info.count}`;
   } else {
     const splat = info[Symbol.for('splat')];
@@ -103,36 +109,36 @@ export function initializeLogger(logDir: string): Logger {
     levels: winston.config.npm.levels,
     format: winston.format.combine(
       winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-    winston.format.errors({ stack: true }),
-    winston.format.splat()
-  ),
-  transports: [
-    new winston.transports.Console({
-      level: process.env.LOG_LEVEL_CONSOLE || 'info',
-      format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.printf(formatConsoleLogMessage)
-      )
-    }),
-    new winston.transports.File({
-      filename: path.join(logDir, 'app.log'),
-      level: process.env.LOG_LEVEL_APP || 'info',
-      format: winston.format.combine(
-        openTelemetryFormat(),
-        winston.format.json()
-      )
-    }),
-    new winston.transports.File({
-      filename: path.join(logDir, 'error.log'),
-      level: 'error',
-      format: winston.format.combine(
-        openTelemetryFormat(),
-        winston.format.json()
-      )
-    })
-  ],
-  exitOnError: false
-});
+      winston.format.errors({ stack: true }),
+      winston.format.splat(),
+    ),
+    transports: [
+      new winston.transports.Console({
+        level: process.env.LOG_LEVEL_CONSOLE || 'info',
+        format: winston.format.combine(
+          winston.format.colorize(),
+          winston.format.printf(formatConsoleLogMessage),
+        ),
+      }),
+      new winston.transports.File({
+        filename: path.join(logDir, 'app.log'),
+        level: process.env.LOG_LEVEL_APP || 'info',
+        format: winston.format.combine(
+          openTelemetryFormat(),
+          winston.format.json(),
+        ),
+      }),
+      new winston.transports.File({
+        filename: path.join(logDir, 'error.log'),
+        level: 'error',
+        format: winston.format.combine(
+          openTelemetryFormat(),
+          winston.format.json(),
+        ),
+      }),
+    ],
+    exitOnError: false,
+  });
 
   logger.info(`Logger initialized successfully. Log directory: ${logDir}`);
   return logger;
@@ -147,8 +153,10 @@ export default {
    */
   get instance() {
     if (!logger) {
-      throw new Error("Logger has not been initialized. Call initializeLogger(logDir) first.");
+      throw new Error(
+        'Logger has not been initialized. Call initializeLogger(logDir) first.',
+      );
     }
     return logger;
-  }
+  },
 };

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -2,20 +2,20 @@ import * as fs from 'fs';
 import * as readline from 'readline';
 
 async function parsePreloadUrls(): Promise<void> {
-    let loadList: string[] = [];
+  let loadList: string[] = [];
 
-    const urlsRl = readline.createInterface({
-        input: fs.createReadStream('src/input.txt'),
-        crlfDelay: Infinity
-    });
+  const urlsRl = readline.createInterface({
+    input: fs.createReadStream('src/input.txt'),
+    crlfDelay: Infinity,
+  });
 
-    for await (const url of urlsRl) {
-        const trimmedUrl: string = url.trim();
-        if (trimmedUrl) {
-            loadList.push(trimmedUrl);
-        }
+  for await (const url of urlsRl) {
+    const trimmedUrl: string = url.trim();
+    if (trimmedUrl) {
+      loadList.push(trimmedUrl);
     }
-    console.log(loadList);
+  }
+  console.log(loadList);
 }
 
 parsePreloadUrls().catch(console.error);

--- a/src/utils/stats-processing.ts
+++ b/src/utils/stats-processing.ts
@@ -11,8 +11,8 @@ import logger from './logger.js';
  * @property {PrebidInstanceData[]} [prebidInstances] - An array of Prebid.js instances found on the site. Optional if no instances detected.
  */
 export interface SiteData {
-    url?: string;
-    prebidInstances?: PrebidInstanceData[];
+  url?: string;
+  prebidInstances?: PrebidInstanceData[];
 }
 
 /**
@@ -22,8 +22,8 @@ export interface SiteData {
  * @property {string[]} [modules] - An array of module names (e.g., "rubiconBidAdapter", "userId") associated with the Prebid.js instance. Optional if no modules detected or applicable.
  */
 export interface PrebidInstanceData {
-    version?: string;
-    modules?: string[];
+  version?: string;
+  modules?: string[];
 }
 
 /**
@@ -33,7 +33,7 @@ export interface PrebidInstanceData {
  * @property {number} [version] - Count for a specific version string.
  */
 export interface VersionDistribution {
-    [version: string]: number;
+  [version: string]: number;
 }
 
 /**
@@ -43,7 +43,7 @@ export interface VersionDistribution {
  * @property {number} [moduleName] - Count for a specific module name.
  */
 export interface ModuleDistribution {
-    [moduleName: string]: number;
+  [moduleName: string]: number;
 }
 
 /**
@@ -56,10 +56,10 @@ export interface ModuleDistribution {
  * @see {@link https://semver.org/ Semantic Versioning}
  */
 export interface VersionComponents {
-    major: number;
-    minor: number;
-    patch: number;
-    preRelease: string | null;
+  major: number;
+  minor: number;
+  patch: number;
+  preRelease: string | null;
 }
 
 /**
@@ -73,12 +73,13 @@ export interface VersionComponents {
  * @property {ModuleDistribution} analyticsAdapter - Distribution of analytics adapter modules.
  * @property {ModuleDistribution} other - Distribution of modules not fitting into other predefined categories.
  */
-export interface CategorizedModules { // Changed from typedef to interface for consistency
-    bidAdapter: ModuleDistribution;
-    idModule: ModuleDistribution;
-    rtdModule: ModuleDistribution;
-    analyticsAdapter: ModuleDistribution;
-    other: ModuleDistribution;
+export interface CategorizedModules {
+  // Changed from typedef to interface for consistency
+  bidAdapter: ModuleDistribution;
+  idModule: ModuleDistribution;
+  rtdModule: ModuleDistribution;
+  analyticsAdapter: ModuleDistribution;
+  other: ModuleDistribution;
 }
 
 /**
@@ -93,12 +94,13 @@ export interface CategorizedModules { // Changed from typedef to interface for c
  * @property {ModuleDistribution} analyticsAdapterWebsites - Distribution of unique websites using specific analytics adapter modules.
  * @property {ModuleDistribution} otherModuleWebsites - Distribution of unique websites using other specific modules not fitting predefined categories.
  */
-export interface ProcessedModuleWebsiteCounts { // Changed from typedef to interface
-    bidAdapterWebsites: ModuleDistribution;
-    idModuleWebsites: ModuleDistribution;
-    rtdModuleWebsites: ModuleDistribution;
-    analyticsAdapterWebsites: ModuleDistribution;
-    otherModuleWebsites: ModuleDistribution;
+export interface ProcessedModuleWebsiteCounts {
+  // Changed from typedef to interface
+  bidAdapterWebsites: ModuleDistribution;
+  idModuleWebsites: ModuleDistribution;
+  rtdModuleWebsites: ModuleDistribution;
+  analyticsAdapterWebsites: ModuleDistribution;
+  otherModuleWebsites: ModuleDistribution;
 }
 
 /**
@@ -113,12 +115,13 @@ export interface ProcessedModuleWebsiteCounts { // Changed from typedef to inter
  * @property {ModuleDistribution} analyticsAdapterInst - Distribution of Prebid.js analytics adapter module instances.
  * @property {ModuleDistribution} otherModuleInst - Distribution of other Prebid.js module instances not fitting predefined categories.
  */
-export interface ProcessedModuleDistribution { // Changed from typedef to interface
-    bidAdapterInst: ModuleDistribution;
-    idModuleInst: ModuleDistribution;
-    rtdModuleInst: ModuleDistribution;
-    analyticsAdapterInst: ModuleDistribution;
-    otherModuleInst: ModuleDistribution;
+export interface ProcessedModuleDistribution {
+  // Changed from typedef to interface
+  bidAdapterInst: ModuleDistribution;
+  idModuleInst: ModuleDistribution;
+  rtdModuleInst: ModuleDistribution;
+  analyticsAdapterInst: ModuleDistribution;
+  otherModuleInst: ModuleDistribution;
 }
 
 /**
@@ -131,12 +134,12 @@ export interface ProcessedModuleDistribution { // Changed from typedef to interf
  * @property {VersionDistribution} customVersions - Distribution of custom or non-standard Prebid.js versions
  *           (e.g., "8.42.0-custom", or versions not matching X.Y.Z or X.Y.Z-pre patterns).
  */
-export interface ProcessedVersionDistribution { // Changed from typedef to interface
-    releaseVersions: VersionDistribution;
-    buildVersions: VersionDistribution;
-    customVersions: VersionDistribution;
+export interface ProcessedVersionDistribution {
+  // Changed from typedef to interface
+  releaseVersions: VersionDistribution;
+  buildVersions: VersionDistribution;
+  customVersions: VersionDistribution;
 }
-
 
 import { DEFAULT_MODULE_CATEGORIES } from '../config/stats-config.js';
 
@@ -163,23 +166,29 @@ import { DEFAULT_MODULE_CATEGORIES } from '../config/stats-config.js';
  *          - For unparseable strings (not matching `vX.Y.Z(-prerelease)`),
  *            returns `{ major: 0, minor: 0, patch: 0, preRelease: originalInputString }`.
  */
-export function parseVersion(versionString: string | undefined): VersionComponents {
-    if (!versionString) {
-        // Optionally log if strict parsing is expected and undefined/null is an issue:
-        // logger.instance.debug('parseVersion received null or undefined versionString.');
-        return { major: 0, minor: 0, patch: 0, preRelease: 'invalid' };
-    }
-    const match: RegExpMatchArray | null = versionString.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
-    if (!match) {
-        logger.instance.warn(`Could not parse version string: "${versionString}" into X.Y.Z format. Returning as custom preRelease.`);
-        return { major: 0, minor: 0, patch: 0, preRelease: versionString };
-    }
-    return {
-        major: parseInt(match[1], 10),
-        minor: parseInt(match[2], 10),
-        patch: parseInt(match[3], 10),
-        preRelease: match[4] || null,
-    };
+export function parseVersion(
+  versionString: string | undefined,
+): VersionComponents {
+  if (!versionString) {
+    // Optionally log if strict parsing is expected and undefined/null is an issue:
+    // logger.instance.debug('parseVersion received null or undefined versionString.');
+    return { major: 0, minor: 0, patch: 0, preRelease: 'invalid' };
+  }
+  const match: RegExpMatchArray | null = versionString.match(
+    /^v?(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/,
+  );
+  if (!match) {
+    logger.instance.warn(
+      `Could not parse version string: "${versionString}" into X.Y.Z format. Returning as custom preRelease.`,
+    );
+    return { major: 0, minor: 0, patch: 0, preRelease: versionString };
+  }
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+    preRelease: match[4] || null,
+  };
 }
 
 /**
@@ -202,26 +211,26 @@ export function parseVersion(versionString: string | undefined): VersionComponen
  * compareVersions("8.0.0-beta", "8.0.0-alpha"); // Returns < 0 (8.0.0-beta is newer than 8.0.0-alpha)
  */
 export function compareVersions(a: string, b: string): number {
-    const vA: VersionComponents = parseVersion(a);
-    const vB: VersionComponents = parseVersion(b);
+  const vA: VersionComponents = parseVersion(a);
+  const vB: VersionComponents = parseVersion(b);
 
-    // Compare major, minor, patch versions in descending order
-    if (vA.major !== vB.major) return vB.major - vA.major; // If vB.major > vA.major, positive (b newer), else negative (a newer)
-    if (vA.minor !== vB.minor) return vB.minor - vA.minor;
-    if (vA.patch !== vB.patch) return vB.patch - vA.patch;
+  // Compare major, minor, patch versions in descending order
+  if (vA.major !== vB.major) return vB.major - vA.major; // If vB.major > vA.major, positive (b newer), else negative (a newer)
+  if (vA.minor !== vB.minor) return vB.minor - vA.minor;
+  if (vA.patch !== vB.patch) return vB.patch - vA.patch;
 
-    // Pre-release handling for descending sort (release > pre-release)
-    // A release version (preRelease is null) is considered newer than a pre-release version.
-    if (vA.preRelease === null && vB.preRelease !== null) return -1; // a is release, b is pre-release; a is newer
-    if (vA.preRelease !== null && vB.preRelease === null) return 1;  // a is pre-release, b is release; b is newer
+  // Pre-release handling for descending sort (release > pre-release)
+  // A release version (preRelease is null) is considered newer than a pre-release version.
+  if (vA.preRelease === null && vB.preRelease !== null) return -1; // a is release, b is pre-release; a is newer
+  if (vA.preRelease !== null && vB.preRelease === null) return 1; // a is pre-release, b is release; b is newer
 
-    // If both are pre-releases (or both null), compare preRelease strings lexicographically.
-    // For descending sort of versions, a "larger" pre-release string (e.g. "beta" vs "alpha") is considered newer.
-    if (vA.preRelease && vB.preRelease) {
-        if (vA.preRelease < vB.preRelease) return 1;  // a is "smaller" (e.g. alpha), so b (e.g. beta) is newer
-        if (vA.preRelease > vB.preRelease) return -1; // a is "larger", so a is newer
-    }
-    return 0;
+  // If both are pre-releases (or both null), compare preRelease strings lexicographically.
+  // For descending sort of versions, a "larger" pre-release string (e.g. "beta" vs "alpha") is considered newer.
+  if (vA.preRelease && vB.preRelease) {
+    if (vA.preRelease < vB.preRelease) return 1; // a is "smaller" (e.g. alpha), so b (e.g. beta) is newer
+    if (vA.preRelease > vB.preRelease) return -1; // a is "larger", so a is newer
+  }
+  return 0;
 }
 
 /**
@@ -236,37 +245,37 @@ export function compareVersions(a: string, b: string): number {
  * @returns An object containing modules categorized into distributions.
  */
 export function _categorizeModules<T>( // Made exportable for potential testing, though still "internal" by convention
-    dataSource: { [moduleName: string]: T },
-    minCountThreshold: number,
-    countExtractor: (item: T) => number,
-    moduleCategoryPredicates: Readonly<typeof DEFAULT_MODULE_CATEGORIES> // Updated, Readonly for safety
+  dataSource: { [moduleName: string]: T },
+  minCountThreshold: number,
+  countExtractor: (item: T) => number,
+  moduleCategoryPredicates: Readonly<typeof DEFAULT_MODULE_CATEGORIES>, // Updated, Readonly for safety
 ): CategorizedModules {
-    const result: CategorizedModules = {
-        bidAdapter: {},
-        idModule: {},
-        rtdModule: {},
-        analyticsAdapter: {},
-        other: {},
-    };
+  const result: CategorizedModules = {
+    bidAdapter: {},
+    idModule: {},
+    rtdModule: {},
+    analyticsAdapter: {},
+    other: {},
+  };
 
-    for (const moduleName in dataSource) {
-        const count = countExtractor(dataSource[moduleName]);
-        if (count < minCountThreshold) continue;
+  for (const moduleName in dataSource) {
+    const count = countExtractor(dataSource[moduleName]);
+    if (count < minCountThreshold) continue;
 
-        let categorized = false;
-        for (const categoryKey in moduleCategoryPredicates) {
-            const key = categoryKey as keyof typeof defaultModuleCategories;
-            if (moduleCategoryPredicates[key](moduleName)) {
-                (result[key] as ModuleDistribution)[moduleName] = count;
-                categorized = true;
-                break;
-            }
-        }
-        if (!categorized) {
-            result.other[moduleName] = count;
-        }
+    let categorized = false;
+    for (const categoryKey in moduleCategoryPredicates) {
+      const key = categoryKey as keyof typeof defaultModuleCategories;
+      if (moduleCategoryPredicates[key](moduleName)) {
+        (result[key] as ModuleDistribution)[moduleName] = count;
+        categorized = true;
+        break;
+      }
     }
-    return result;
+    if (!categorized) {
+      result.other[moduleName] = count;
+    }
+  }
+  return result;
 }
 
 /**
@@ -278,22 +287,22 @@ export function _categorizeModules<T>( // Made exportable for potential testing,
  * @returns Categorized module distributions based on website counts.
  */
 export function processModuleWebsiteCounts(
-    moduleWebsiteData: { [moduleName: string]: Set<string> },
-    minCountThreshold: number
+  moduleWebsiteData: { [moduleName: string]: Set<string> },
+  minCountThreshold: number,
 ): ProcessedModuleWebsiteCounts {
-    const categorized = _categorizeModules<Set<string>>(
-        moduleWebsiteData,
-        minCountThreshold,
-        (dataSet: Set<string>) => dataSet.size,
-        DEFAULT_MODULE_CATEGORIES // Updated to use imported constant
-    );
-    return {
-        bidAdapterWebsites: categorized.bidAdapter,
-        idModuleWebsites: categorized.idModule,
-        rtdModuleWebsites: categorized.rtdModule,
-        analyticsAdapterWebsites: categorized.analyticsAdapter,
-        otherModuleWebsites: categorized.other,
-    };
+  const categorized = _categorizeModules<Set<string>>(
+    moduleWebsiteData,
+    minCountThreshold,
+    (dataSet: Set<string>) => dataSet.size,
+    DEFAULT_MODULE_CATEGORIES, // Updated to use imported constant
+  );
+  return {
+    bidAdapterWebsites: categorized.bidAdapter,
+    idModuleWebsites: categorized.idModule,
+    rtdModuleWebsites: categorized.rtdModule,
+    analyticsAdapterWebsites: categorized.analyticsAdapter,
+    otherModuleWebsites: categorized.other,
+  };
 }
 
 /**
@@ -305,28 +314,30 @@ export function processModuleWebsiteCounts(
  * @returns Categorized module distributions based on instance counts.
  */
 export function processModuleDistribution(
-    rawModuleCounts: ModuleDistribution,
-    minCountThreshold: number
+  rawModuleCounts: ModuleDistribution,
+  minCountThreshold: number,
 ): ProcessedModuleDistribution {
-    const sortedRawModules: string[] = Object.keys(rawModuleCounts).sort((a, b) => rawModuleCounts[b] - rawModuleCounts[a]);
-    const sortedRawModuleCounts: ModuleDistribution = {};
-    for (const moduleName of sortedRawModules) {
-        sortedRawModuleCounts[moduleName] = rawModuleCounts[moduleName];
-    }
+  const sortedRawModules: string[] = Object.keys(rawModuleCounts).sort(
+    (a, b) => rawModuleCounts[b] - rawModuleCounts[a],
+  );
+  const sortedRawModuleCounts: ModuleDistribution = {};
+  for (const moduleName of sortedRawModules) {
+    sortedRawModuleCounts[moduleName] = rawModuleCounts[moduleName];
+  }
 
-    const categorized = _categorizeModules<number>(
-        sortedRawModuleCounts,
-        minCountThreshold,
-        (count: number) => count,
-        DEFAULT_MODULE_CATEGORIES // Updated to use imported constant
-    );
-    return {
-        bidAdapterInst: categorized.bidAdapter,
-        idModuleInst: categorized.idModule,
-        rtdModuleInst: categorized.rtdModule,
-        analyticsAdapterInst: categorized.analyticsAdapter,
-        otherModuleInst: categorized.other,
-    };
+  const categorized = _categorizeModules<number>(
+    sortedRawModuleCounts,
+    minCountThreshold,
+    (count: number) => count,
+    DEFAULT_MODULE_CATEGORIES, // Updated to use imported constant
+  );
+  return {
+    bidAdapterInst: categorized.bidAdapter,
+    idModuleInst: categorized.idModule,
+    rtdModuleInst: categorized.rtdModule,
+    analyticsAdapterInst: categorized.analyticsAdapter,
+    otherModuleInst: categorized.other,
+  };
 }
 
 /**
@@ -336,31 +347,39 @@ export function processModuleDistribution(
  * @param rawVersionCounts - Object with version strings as keys and raw counts as values.
  * @returns Categorized version distributions.
  */
-export function processVersionDistribution(rawVersionCounts: VersionDistribution): ProcessedVersionDistribution {
-    const releaseVersions: VersionDistribution = {};
-    const buildVersions: VersionDistribution = {};
-    const customVersions: VersionDistribution = {};
-    const sortedRawVersions: string[] = Object.keys(rawVersionCounts).sort(compareVersions);
+export function processVersionDistribution(
+  rawVersionCounts: VersionDistribution,
+): ProcessedVersionDistribution {
+  const releaseVersions: VersionDistribution = {};
+  const buildVersions: VersionDistribution = {};
+  const customVersions: VersionDistribution = {};
+  const sortedRawVersions: string[] =
+    Object.keys(rawVersionCounts).sort(compareVersions);
 
-    for (const version of sortedRawVersions) {
-        const count: number = rawVersionCounts[version];
-        const cleanedVersion: string = version.startsWith('v') ? version.substring(1) : version;
-        const originalVersionForCategorization: string = version;
+  for (const version of sortedRawVersions) {
+    const count: number = rawVersionCounts[version];
+    const cleanedVersion: string = version.startsWith('v')
+      ? version.substring(1)
+      : version;
+    const originalVersionForCategorization: string = version;
 
-        if (originalVersionForCategorization.endsWith('-pre')) {
-            buildVersions[cleanedVersion] = count;
-        } else if (originalVersionForCategorization.includes('-')) {
-            customVersions[cleanedVersion] = count;
-        } else {
-            const parsedForValidation = parseVersion(cleanedVersion);
-            if (parsedForValidation.preRelease === null && cleanedVersion.match(/^\d+\.\d+\.\d+$/)) {
-                 releaseVersions[cleanedVersion] = count;
-            } else {
-                 customVersions[cleanedVersion] = count;
-            }
-        }
+    if (originalVersionForCategorization.endsWith('-pre')) {
+      buildVersions[cleanedVersion] = count;
+    } else if (originalVersionForCategorization.includes('-')) {
+      customVersions[cleanedVersion] = count;
+    } else {
+      const parsedForValidation = parseVersion(cleanedVersion);
+      if (
+        parsedForValidation.preRelease === null &&
+        cleanedVersion.match(/^\d+\.\d+\.\d+$/)
+      ) {
+        releaseVersions[cleanedVersion] = count;
+      } else {
+        customVersions[cleanedVersion] = count;
+      }
     }
-    return { releaseVersions, buildVersions, customVersions };
+  }
+  return { releaseVersions, buildVersions, customVersions };
 }
 
 /**
@@ -378,57 +397,61 @@ export function processVersionDistribution(rawVersionCounts: VersionDistribution
  * @param moduleWebsiteData - Map to accumulate unique websites per module.
  */
 export function _processSiteEntries( // Made exportable for potential testing
-    siteEntries: SiteData[],
-    currentFileSourceInfo: string,
-    uniqueUrls: Set<string>,
-    urlsWithPrebid: Set<string>,
-    rawVersionCounts: VersionDistribution,
-    rawModuleCounts: ModuleDistribution,
-    moduleWebsiteData: { [moduleName: string]: Set<string> }
+  siteEntries: SiteData[],
+  currentFileSourceInfo: string,
+  uniqueUrls: Set<string>,
+  urlsWithPrebid: Set<string>,
+  rawVersionCounts: VersionDistribution,
+  rawModuleCounts: ModuleDistribution,
+  moduleWebsiteData: { [moduleName: string]: Set<string> },
 ): void {
-    if (!Array.isArray(siteEntries)) {
-        logger.instance.warn(`_processSiteEntries received non-array data for ${currentFileSourceInfo}`);
-        return;
+  if (!Array.isArray(siteEntries)) {
+    logger.instance.warn(
+      `_processSiteEntries received non-array data for ${currentFileSourceInfo}`,
+    );
+    return;
+  }
+
+  siteEntries.forEach((siteData: SiteData) => {
+    const currentUrl: string | undefined = siteData?.url?.trim();
+    let hasPrebidInstanceOnSite: boolean = false;
+
+    if (currentUrl) uniqueUrls.add(currentUrl);
+
+    if (Array.isArray(siteData.prebidInstances)) {
+      siteData.prebidInstances.forEach((instance: PrebidInstanceData) => {
+        if (!instance) return;
+        hasPrebidInstanceOnSite = true;
+
+        if (typeof instance.version === 'string') {
+          const version: string = instance.version.trim();
+          if (version)
+            rawVersionCounts[version] = (rawVersionCounts[version] || 0) + 1;
+        }
+
+        if (Array.isArray(instance.modules)) {
+          instance.modules.forEach((moduleName: string) => {
+            if (typeof moduleName === 'string') {
+              const trimmedModule: string = moduleName.trim();
+              if (trimmedModule) {
+                rawModuleCounts[trimmedModule] =
+                  (rawModuleCounts[trimmedModule] || 0) + 1;
+                if (currentUrl) {
+                  if (!moduleWebsiteData[trimmedModule]) {
+                    moduleWebsiteData[trimmedModule] = new Set();
+                  }
+                  moduleWebsiteData[trimmedModule].add(currentUrl);
+                }
+              }
+            }
+          });
+        }
+      });
     }
-
-    siteEntries.forEach((siteData: SiteData) => {
-        const currentUrl: string | undefined = siteData?.url?.trim();
-        let hasPrebidInstanceOnSite: boolean = false;
-
-        if (currentUrl) uniqueUrls.add(currentUrl);
-
-        if (Array.isArray(siteData.prebidInstances)) {
-            siteData.prebidInstances.forEach((instance: PrebidInstanceData) => {
-                if (!instance) return;
-                hasPrebidInstanceOnSite = true;
-
-                if (typeof instance.version === 'string') {
-                    const version: string = instance.version.trim();
-                    if (version) rawVersionCounts[version] = (rawVersionCounts[version] || 0) + 1;
-                }
-
-                if (Array.isArray(instance.modules)) {
-                    instance.modules.forEach((moduleName: string) => {
-                        if (typeof moduleName === 'string') {
-                            const trimmedModule: string = moduleName.trim();
-                            if (trimmedModule) {
-                                rawModuleCounts[trimmedModule] = (rawModuleCounts[trimmedModule] || 0) + 1;
-                                if (currentUrl) {
-                                    if (!moduleWebsiteData[trimmedModule]) {
-                                        moduleWebsiteData[trimmedModule] = new Set();
-                                    }
-                                    moduleWebsiteData[trimmedModule].add(currentUrl);
-                                }
-                            }
-                        }
-                    });
-                }
-            });
-        }
-        if (currentUrl && hasPrebidInstanceOnSite) {
-            urlsWithPrebid.add(currentUrl);
-        }
-    });
+    if (currentUrl && hasPrebidInstanceOnSite) {
+      urlsWithPrebid.add(currentUrl);
+    }
+  });
 }
 
 // logger is imported as _processSiteEntries uses it.

--- a/tests/inspect.test.ts
+++ b/tests/inspect.test.ts
@@ -1,7 +1,7 @@
-import {expect, test, vi, describe, beforeEach, afterEach} from 'vitest'
-import Inspect from '../src/commands/inspect' // Adjust path as needed
-import {mkdir, writeFile, readFile, rm} from 'fs/promises'
-import * as path from 'path'
+import { expect, test, vi, describe, beforeEach, afterEach } from 'vitest';
+import Inspect from '../src/commands/inspect'; // Adjust path as needed
+import { mkdir, writeFile, readFile, rm } from 'fs/promises';
+import * as path from 'path';
 import fetch from 'node-fetch';
 
 // Mock node-fetch
@@ -82,17 +82,32 @@ describe('Inspect Command', () => {
 
   test('should use custom filename when provided', async () => {
     const customFilename = 'my-custom-inspection';
-    const argv = [MOCKED_URL, '--output-dir', MOCKED_OUTPUT_DIR, '--filename', customFilename];
+    const argv = [
+      MOCKED_URL,
+      '--output-dir',
+      MOCKED_OUTPUT_DIR,
+      '--filename',
+      customFilename,
+    ];
     const inspectCommand = new Inspect(argv, mockConfig as any);
     await inspectCommand.run();
 
-    const expectedFilePath = path.join(MOCKED_OUTPUT_DIR, `${customFilename}.json`);
+    const expectedFilePath = path.join(
+      MOCKED_OUTPUT_DIR,
+      `${customFilename}.json`,
+    );
     const content = JSON.parse(await readFile(expectedFilePath, 'utf-8'));
     expect(content.request.url).toBe(MOCKED_URL);
   });
 
   test('should save as basic HAR format when specified', async () => {
-    const argv = [MOCKED_URL, '--output-dir', MOCKED_OUTPUT_DIR, '--format', 'har'];
+    const argv = [
+      MOCKED_URL,
+      '--output-dir',
+      MOCKED_OUTPUT_DIR,
+      '--format',
+      'har',
+    ];
     const inspectCommand = new Inspect(argv, mockConfig as any);
     await inspectCommand.run();
 
@@ -103,11 +118,15 @@ describe('Inspect Command', () => {
     const filePath = path.join(MOCKED_OUTPUT_DIR, files[0]);
     const content = JSON.parse(await readFile(filePath, 'utf-8'));
 
-    expect(content.log.creator.name).toBe('prebid-integration-monitor/inspect-command');
+    expect(content.log.creator.name).toBe(
+      'prebid-integration-monitor/inspect-command',
+    );
     expect(content.log.entries.length).toBe(1);
     expect(content.log.entries[0].request.url).toBe(MOCKED_URL);
     expect(content.log.entries[0].response.status).toBe(200);
-    expect(content.log.entries[0].response.content.text).toBe(MOCKED_RESPONSE_BODY);
+    expect(content.log.entries[0].response.content.text).toBe(
+      MOCKED_RESPONSE_BODY,
+    );
   });
 
   test('should handle fetch error gracefully', async () => {

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -89,10 +89,26 @@ describe('updateAndCleanStats', () => {
    * @param {FinalApiData} actualData - The actual data from `api.json`.
    * @param {SiteCounts} expectedCounts - The expected site counts.
    */
-  function assertSiteCounts(actualData: FinalApiData, expectedCounts: { visitedSites: number; monitoredSites: number; prebidSites: number; }) {
-    expect(actualData.visitedSites, `Expected visitedSites to be ${expectedCounts.visitedSites}`).toBe(expectedCounts.visitedSites);
-    expect(actualData.monitoredSites, `Expected monitoredSites to be ${expectedCounts.monitoredSites}`).toBe(expectedCounts.monitoredSites);
-    expect(actualData.prebidSites, `Expected prebidSites to be ${expectedCounts.prebidSites}`).toBe(expectedCounts.prebidSites);
+  function assertSiteCounts(
+    actualData: FinalApiData,
+    expectedCounts: {
+      visitedSites: number;
+      monitoredSites: number;
+      prebidSites: number;
+    },
+  ) {
+    expect(
+      actualData.visitedSites,
+      `Expected visitedSites to be ${expectedCounts.visitedSites}`,
+    ).toBe(expectedCounts.visitedSites);
+    expect(
+      actualData.monitoredSites,
+      `Expected monitoredSites to be ${expectedCounts.monitoredSites}`,
+    ).toBe(expectedCounts.monitoredSites);
+    expect(
+      actualData.prebidSites,
+      `Expected prebidSites to be ${expectedCounts.prebidSites}`,
+    ).toBe(expectedCounts.prebidSites);
   }
 
   /**
@@ -107,10 +123,25 @@ describe('updateAndCleanStats', () => {
    * @param {FinalApiData} actualData - The actual data from `api.json`.
    * @param {VersionCounts} expectedCounts - The expected version counts.
    */
-  function assertVersionCounts(actualData: FinalApiData, expectedCounts: { releaseVersions: {[key: string]: number}, buildVersions: {[key: string]: number}, customVersions: {[key: string]: number}}) {
-    expect(actualData.releaseVersions, 'Expected releaseVersions to match').toEqual(expectedCounts.releaseVersions);
-    expect(actualData.buildVersions, 'Expected buildVersions to match').toEqual(expectedCounts.buildVersions);
-    expect(actualData.customVersions, 'Expected customVersions to match').toEqual(expectedCounts.customVersions);
+  function assertVersionCounts(
+    actualData: FinalApiData,
+    expectedCounts: {
+      releaseVersions: { [key: string]: number };
+      buildVersions: { [key: string]: number };
+      customVersions: { [key: string]: number };
+    },
+  ) {
+    expect(
+      actualData.releaseVersions,
+      'Expected releaseVersions to match',
+    ).toEqual(expectedCounts.releaseVersions);
+    expect(actualData.buildVersions, 'Expected buildVersions to match').toEqual(
+      expectedCounts.buildVersions,
+    );
+    expect(
+      actualData.customVersions,
+      'Expected customVersions to match',
+    ).toEqual(expectedCounts.customVersions);
   }
 
   /**
@@ -128,12 +159,28 @@ describe('updateAndCleanStats', () => {
    * @param {Partial<ModuleInstanceCounts>} expectedCounts - The expected module instance counts.
    *                                                        Use Partial as some categories might be undefined if no modules meet threshold.
    */
-  function assertModuleInstanceCounts(actualData: FinalApiData, expectedCounts: Partial<ModuleInstanceCounts>) {
-    expect(actualData.bidAdapterInst, 'Expected bidAdapterInst to match').toEqual(expectedCounts.bidAdapterInst || {});
-    expect(actualData.idModuleInst, 'Expected idModuleInst to match').toEqual(expectedCounts.idModuleInst || {});
-    expect(actualData.analyticsAdapterInst, 'Expected analyticsAdapterInst to match').toEqual(expectedCounts.analyticsAdapterInst || {});
-    expect(actualData.rtdModuleInst, 'Expected rtdModuleInst to match').toEqual(expectedCounts.rtdModuleInst || {});
-    expect(actualData.otherModuleInst, 'Expected otherModuleInst to match').toEqual(expectedCounts.otherModuleInst || {});
+  function assertModuleInstanceCounts(
+    actualData: FinalApiData,
+    expectedCounts: Partial<ModuleInstanceCounts>,
+  ) {
+    expect(
+      actualData.bidAdapterInst,
+      'Expected bidAdapterInst to match',
+    ).toEqual(expectedCounts.bidAdapterInst || {});
+    expect(actualData.idModuleInst, 'Expected idModuleInst to match').toEqual(
+      expectedCounts.idModuleInst || {},
+    );
+    expect(
+      actualData.analyticsAdapterInst,
+      'Expected analyticsAdapterInst to match',
+    ).toEqual(expectedCounts.analyticsAdapterInst || {});
+    expect(actualData.rtdModuleInst, 'Expected rtdModuleInst to match').toEqual(
+      expectedCounts.rtdModuleInst || {},
+    );
+    expect(
+      actualData.otherModuleInst,
+      'Expected otherModuleInst to match',
+    ).toEqual(expectedCounts.otherModuleInst || {});
   }
 
   /**
@@ -150,12 +197,30 @@ describe('updateAndCleanStats', () => {
    * @param {FinalApiData} actualData - The actual data from `api.json`.
    * @param {Partial<ModuleWebsiteCounts>} expectedCounts - The expected module website counts.
    */
-  function assertModuleWebsiteCounts(actualData: FinalApiData, expectedCounts: Partial<ModuleWebsiteCounts>) {
-    expect(actualData.bidAdapterWebsites, 'Expected bidAdapterWebsites to match').toEqual(expectedCounts.bidAdapterWebsites || {});
-    expect(actualData.idModuleWebsites, 'Expected idModuleWebsites to match').toEqual(expectedCounts.idModuleWebsites || {});
-    expect(actualData.analyticsAdapterWebsites, 'Expected analyticsAdapterWebsites to match').toEqual(expectedCounts.analyticsAdapterWebsites || {});
-    expect(actualData.rtdModuleWebsites, 'Expected rtdModuleWebsites to match').toEqual(expectedCounts.rtdModuleWebsites || {});
-    expect(actualData.otherModuleWebsites, 'Expected otherModuleWebsites to match').toEqual(expectedCounts.otherModuleWebsites || {});
+  function assertModuleWebsiteCounts(
+    actualData: FinalApiData,
+    expectedCounts: Partial<ModuleWebsiteCounts>,
+  ) {
+    expect(
+      actualData.bidAdapterWebsites,
+      'Expected bidAdapterWebsites to match',
+    ).toEqual(expectedCounts.bidAdapterWebsites || {});
+    expect(
+      actualData.idModuleWebsites,
+      'Expected idModuleWebsites to match',
+    ).toEqual(expectedCounts.idModuleWebsites || {});
+    expect(
+      actualData.analyticsAdapterWebsites,
+      'Expected analyticsAdapterWebsites to match',
+    ).toEqual(expectedCounts.analyticsAdapterWebsites || {});
+    expect(
+      actualData.rtdModuleWebsites,
+      'Expected rtdModuleWebsites to match',
+    ).toEqual(expectedCounts.rtdModuleWebsites || {});
+    expect(
+      actualData.otherModuleWebsites,
+      'Expected otherModuleWebsites to match',
+    ).toEqual(expectedCounts.otherModuleWebsites || {});
   }
 
   /**
@@ -164,76 +229,171 @@ describe('updateAndCleanStats', () => {
    */
   const mockComprehensiveData = {
     [storePath]: {
-      'Jan': {
+      Jan: {
         'data1.json': JSON.stringify([
           {
             url: 'http://site1.com',
             prebidInstances: [
-              { version: 'v8.2.0', modules: ['rubiconBidAdapter', 'criteoIdSystem', 'sharedIdSystem', 'adagioAnalyticsAdapter', 'coreModuleOnly'] },
-              { version: 'v8.1.0', modules: ['criteoIdSystem', 'anotherModule'] } // `anotherModule` helps test website count for criteoIdSystem vs other modules on same site
-            ]
+              {
+                version: 'v8.2.0',
+                modules: [
+                  'rubiconBidAdapter',
+                  'criteoIdSystem',
+                  'sharedIdSystem',
+                  'adagioAnalyticsAdapter',
+                  'coreModuleOnly',
+                ],
+              },
+              {
+                version: 'v8.1.0',
+                modules: ['criteoIdSystem', 'anotherModule'],
+              }, // `anotherModule` helps test website count for criteoIdSystem vs other modules on same site
+            ],
           },
           {
             url: 'http://site2.com',
             prebidInstances: [
-              { version: '7.53.0', modules: ['rubiconBidAdapter', 'id5IdSystem', 'connectIdSystem', 'coreModuleOnly', 'belowThresholdModule'] } // `belowThresholdModule` intended to be filtered.
-            ]
+              {
+                version: '7.53.0',
+                modules: [
+                  'rubiconBidAdapter',
+                  'id5IdSystem',
+                  'connectIdSystem',
+                  'coreModuleOnly',
+                  'belowThresholdModule',
+                ],
+              }, // `belowThresholdModule` intended to be filtered.
+            ],
           },
           {
             url: 'http://site3.com',
-            prebidInstances: [{}] // Tests handling of instance with no version/modules.
-          }
+            prebidInstances: [{}], // Tests handling of instance with no version/modules.
+          },
         ]),
         'data2.json': JSON.stringify([
           {
             url: 'http://site4.com',
             prebidInstances: [
-              { version: 'v9.10.0-pre', modules: ['rubiconBidAdapter', 'pubCommonId', 'realTimeData', 'enrichmentRtdProvider'] } // `realTimeData` intended to be below threshold.
-            ]
+              {
+                version: 'v9.10.0-pre',
+                modules: [
+                  'rubiconBidAdapter',
+                  'pubCommonId',
+                  'realTimeData',
+                  'enrichmentRtdProvider',
+                ],
+              }, // `realTimeData` intended to be below threshold.
+            ],
           },
           {
             url: 'http://site5.com',
             prebidInstances: [
-              { version: 'v1.2.3-custom', modules: ['rubiconBidAdapter', 'utiqSystem', 'customAnalyticsAdapter'] }
-            ]
+              {
+                version: 'v1.2.3-custom',
+                modules: [
+                  'rubiconBidAdapter',
+                  'utiqSystem',
+                  'customAnalyticsAdapter',
+                ],
+              },
+            ],
           },
           {
             url: 'http://site6.com',
             prebidInstances: [
-              { version: '9.35', modules: ['rubiconBidAdapter', 'trustpidSystem', 'coreModuleOnly'] }
-            ]
-          }
+              {
+                version: '9.35',
+                modules: [
+                  'rubiconBidAdapter',
+                  'trustpidSystem',
+                  'coreModuleOnly',
+                ],
+              },
+            ],
+          },
         ]),
       },
-      'Feb': {
+      Feb: {
         'data3.json': JSON.stringify([
           {
             url: 'http://site1.com', // Repeat site1
             prebidInstances: [
-              { version: 'v8.2.0', modules: ['rubiconBidAdapter', 'criteoIdSystem', 'appnexusBidAdapter'] }
-            ]
+              {
+                version: 'v8.2.0',
+                modules: [
+                  'rubiconBidAdapter',
+                  'criteoIdSystem',
+                  'appnexusBidAdapter',
+                ],
+              },
+            ],
           },
           {
             url: 'http://site7.com', // No Prebid
-          }
-        ])
+          },
+        ]),
       },
-      'Mar': { // Add more data to ensure some modules pass threshold
+      Mar: {
+        // Add more data to ensure some modules pass threshold
         'data4.json': JSON.stringify([
-          { url: 'http://site8.com', prebidInstances: [{ version: 'v8.2.0', modules: ['rubiconBidAdapter', 'appnexusBidAdapter', 'criteoIdSystem'] }] },
-          { url: 'http://site9.com', prebidInstances: [{ version: 'v8.2.0', modules: ['rubiconBidAdapter', 'appnexusBidAdapter', 'criteoIdSystem'] }] },
-          { url: 'http://site10.com', prebidInstances: [{ version: 'v8.2.0', modules: ['rubiconBidAdapter', 'appnexusBidAdapter', 'criteoIdSystem', 'sharedIdSystem'] }] },
-          { url: 'http://site11.com', prebidInstances: [{ version: 'v8.2.0', modules: ['appnexusBidAdapter', 'sharedIdSystem'] }] },
-        ])
-      }
+          {
+            url: 'http://site8.com',
+            prebidInstances: [
+              {
+                version: 'v8.2.0',
+                modules: [
+                  'rubiconBidAdapter',
+                  'appnexusBidAdapter',
+                  'criteoIdSystem',
+                ],
+              },
+            ],
+          },
+          {
+            url: 'http://site9.com',
+            prebidInstances: [
+              {
+                version: 'v8.2.0',
+                modules: [
+                  'rubiconBidAdapter',
+                  'appnexusBidAdapter',
+                  'criteoIdSystem',
+                ],
+              },
+            ],
+          },
+          {
+            url: 'http://site10.com',
+            prebidInstances: [
+              {
+                version: 'v8.2.0',
+                modules: [
+                  'rubiconBidAdapter',
+                  'appnexusBidAdapter',
+                  'criteoIdSystem',
+                  'sharedIdSystem',
+                ],
+              },
+            ],
+          },
+          {
+            url: 'http://site11.com',
+            prebidInstances: [
+              {
+                version: 'v8.2.0',
+                modules: ['appnexusBidAdapter', 'sharedIdSystem'],
+              },
+            ],
+          },
+        ]),
+      },
     },
-    'api': {} // api directory must exist for writeFile to place api.json
+    api: {}, // api directory must exist for writeFile to place api.json
   };
 
   it('should correctly summarize and clean stats, then write to api/api.json', async () => {
     // Copied mock data structure from the original test plan, adjusted for absolute storePath
     mockFs(mockComprehensiveData);
-
 
     await updateAndCleanStats();
 
@@ -242,20 +402,24 @@ describe('updateAndCleanStats', () => {
     const outputData = readMockJson(outputPath) as FinalApiData; // Cast here for type safety in helpers
 
     // Assertions from the original test plan
-    assertSiteCounts(outputData, { visitedSites: 11, monitoredSites: 11, prebidSites: 10 });
+    assertSiteCounts(outputData, {
+      visitedSites: 11,
+      monitoredSites: 11,
+      prebidSites: 10,
+    });
 
     assertVersionCounts(outputData, {
       releaseVersions: { '8.2.0': 6, '7.53.0': 1, '9.35': 1 },
       buildVersions: { '9.10.0-pre': 1 },
-      customVersions: { '1.2.3-custom': 1 }
+      customVersions: { '1.2.3-custom': 1 },
     });
     // Specific check for a version that should NOT be in customVersions after re-categorization
     expect(outputData.customVersions['9.35']).toBeUndefined();
 
     // Module counts based on MIN_COUNT_THRESHOLD = 5 (threshold from update_stats.js)
     assertModuleInstanceCounts(outputData, {
-      bidAdapterInst: { 'rubiconBidAdapter': 9, 'appnexusBidAdapter': 5 },
-      idModuleInst: { 'criteoIdSystem': 6 },
+      bidAdapterInst: { rubiconBidAdapter: 9, appnexusBidAdapter: 5 },
+      idModuleInst: { criteoIdSystem: 6 },
       // analyticsAdapterInst, rtdModuleInst, otherModuleInst will be checked for absence of certain modules
     });
 
@@ -263,15 +427,16 @@ describe('updateAndCleanStats', () => {
     expect(outputData.idModuleInst['sharedIdSystem']).toBeUndefined();
     expect(outputData.otherModuleInst['coreModuleOnly']).toBeUndefined();
     expect(outputData.rtdModuleInst['realTimeData']).toBeUndefined();
-    expect(outputData.analyticsAdapterInst['adagioAnalyticsAdapter']).toBeUndefined();
+    expect(
+      outputData.analyticsAdapterInst['adagioAnalyticsAdapter'],
+    ).toBeUndefined();
     expect(outputData.bidAdapterInst['nonExistentAdapter']).toBeUndefined();
     expect(outputData.otherModuleInst['belowThresholdModule']).toBeUndefined();
-
 
     // Website Counts (New Assertions)
     // MIN_COUNT_THRESHOLD = 5 also applies to website counts
     assertModuleWebsiteCounts(outputData, {
-      bidAdapterWebsites: { 'rubiconBidAdapter': 8, 'appnexusBidAdapter': 5 },
+      bidAdapterWebsites: { rubiconBidAdapter: 8, appnexusBidAdapter: 5 },
       // idModuleWebsites, analyticsAdapterWebsites, rtdModuleWebsites, otherModuleWebsites will be checked for absence of certain modules
     });
 
@@ -284,10 +449,12 @@ describe('updateAndCleanStats', () => {
     expect(outputData.otherModuleWebsites['coreModuleOnly']).toBeUndefined();
     // anotherModule is on 1 unique site (site1), below threshold
     expect(outputData.otherModuleWebsites['anotherModule']).toBeUndefined();
-    
+
     // Check categories that should be empty based on current data
     expect(Object.keys(outputData.rtdModuleWebsites || {}).length).toBe(0);
-    expect(Object.keys(outputData.analyticsAdapterWebsites || {}).length).toBe(0);
+    expect(Object.keys(outputData.analyticsAdapterWebsites || {}).length).toBe(
+      0,
+    );
   });
 
   /**
@@ -303,9 +470,10 @@ describe('updateAndCleanStats', () => {
     // outputDir in update_stats.ts resolves to path.join(__dirname, '..', 'store')
     // where __dirname is /app/src/utils, so outputDir is /app/src/store
     // const storePath = path.resolve(process.cwd(), 'src', 'store'); // Now defined at the describe level
-    mockFs({ // Define mock structure for this specific test
+    mockFs({
+      // Define mock structure for this specific test
       [storePath]: {}, // Mock the specific absolute path
-      'api': {} // api directory must exist for writeFile to place api.json
+      api: {}, // api directory must exist for writeFile to place api.json
     });
 
     await updateAndCleanStats();
@@ -334,10 +502,10 @@ describe('updateAndCleanStats', () => {
     // const storePath = path.resolve(process.cwd(), 'src', 'store'); // Now defined at the describe level
     mockFs({
       [storePath]: {
-        'Jan': {}, // Empty month directory
-        'Feb': {}  // Another empty month directory
+        Jan: {}, // Empty month directory
+        Feb: {}, // Another empty month directory
       },
-      'api': {}
+      api: {},
     });
 
     // Removed incorrect console.log from here
@@ -361,9 +529,9 @@ describe('updateAndCleanStats', () => {
     // const storePath = path.resolve(process.cwd(), 'src', 'store'); // Now defined at the describe level
     mockFs({
       [storePath]: {
-        'Jan': { 'not-a-json.txt': 'hello' }, // Month directory with a non-JSON file
+        Jan: { 'not-a-json.txt': 'hello' }, // Month directory with a non-JSON file
       },
-      'api': {}
+      api: {},
     });
     await updateAndCleanStats();
     const outputData = readMockJson(path.join('api', 'api.json'));


### PR DESCRIPTION
I've installed and configured ESLint and Prettier to improve code quality and consistency for you.

Key changes:
- Added ESLint and Prettier dependencies.
- Created ESLint (`eslint.config.js`) and Prettier (`.prettierrc.cjs`) configuration files.
- Added `.prettierignore` to exclude specific files from Prettier formatting.
- Added `lint` and `format` scripts to `package.json` for easy execution.
- Ran initial formatting and linting.
- Updated `README.md` with instructions on how to use the new linting and formatting tools.

Note: Pre-existing lint errors remain in the codebase. My attempts to fix them were hindered by persistent file modification issues. These errors (including a parsing error in `tests/cli.test.ts`, `require` imports, unused variables, and `any` types) will need to be addressed separately.