### PR TITLE
Fix: Correct syntax error in cli.test.ts

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1839,3 +1839,4 @@ describe('CLI Tests for Local File Inputs (inputFile argument)', () => {
         expect(csvFileContent.trim()).toBe(csvContent.trim(), 'CSV file used as inputFile should not be emptied.');
     }, testTimeout);
 });
+});


### PR DESCRIPTION
Adds a missing closing parenthesis and curly brace to the describe block at the end of the tests/cli.test.ts file.