### PR TITLE
Feat: Handle major.minor-prerelease versions in stats

### DIFF
--- a/src/utils/__tests__/stats-processing.test.ts
+++ b/src/utils/__tests__/stats-processing.test.ts
@@ -89,13 +89,6 @@ describe('stats-processing', () => {
         patch: 0,
         preRelease: 'abc',
       });
-      // The case for '1.2' is now handled by 'should correctly parse "1.2" as major.minor'
-      // expect(parseVersion('1.2')).toEqual<VersionComponents>({
-      //   major: 0,
-      //   minor: 0,
-      //   patch: 0,
-      //   preRelease: '1.2',
-      // });
       expect(parseVersion('1.beta')).toEqual<VersionComponents>({
         major: 0,
         minor: 0,
@@ -166,7 +159,6 @@ describe('stats-processing', () => {
       );
     });
 
-    // This test case was previously in 'should handle malformed version strings'
     // It's updated to reflect the new behavior for "1.2"
     it('should correctly parse "1.2" as major.minor and not log a warning', () => {
       const warnSpy = vi.spyOn(logger.instance, 'warn');

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -447,11 +447,6 @@ describe('updateAndCleanStats', () => {
     // The version "9.35" should now be "9.35.0" in releaseVersions, not in customVersions.
 
     // Module counts based on MIN_COUNT_THRESHOLD = 5 (threshold from update_stats.js)
-    // Need to update module counts if the new sites affect them and they pass the threshold
-    // rubiconBidAdapter: 9 (original) + 1 (site13) = 10
-    // appnexusBidAdapter: 5 (original) + 1 (site12) = 6
-    // criteoIdSystem: 6 (original) + 1 (site12) = 7
-    // sharedIdSystem: was undefined (3, below threshold 5) + 1 (site13) = 4, still undefined.
     assertModuleInstanceCounts(outputData, {
       bidAdapterInst: { rubiconBidAdapter: 10, appnexusBidAdapter: 6 },
       idModuleInst: { criteoIdSystem: 7 },


### PR DESCRIPTION
This commit enhances the version parsing and processing in `stats:generate` to correctly handle Prebid.js versions specified with "major.minor-prerelease" formats (e.g., "9.35-pre", "v10.2-alpha").

Key changes:
- `parseVersion` utility updated to:
    - Recognize "major.minor-prerelease" strings.
    - Default the patch version to "0" (e.g., "9.35-pre" becomes components for 9.35.0-pre).
    - Correctly parse the pre-release identifier.
    - The order of regex checks in `parseVersion` is updated to ensure `major.minor-prerelease` is checked before `major.minor`.
- `processVersionDistribution` utility updated to:
    - Categorize these normalized versions correctly: - Versions ending in ".0-pre" (e.g., "9.35.0-pre") are placed in `buildVersions`. - Versions ending in ".0-<other_prerelease>" (e.g., "10.2.0-alpha") are placed in `customVersions`.
- JSDoc for `parseVersion` updated to include the new format and parsing logic.
- Unit tests for `parseVersion` extended to cover "major.minor-prerelease" cases and ensure correct warning messages.
- Integration tests for `stats:generate` updated with new mock data to verify that these versions are correctly processed and appear in the final `api.json` under the appropriate categories (`buildVersions` or `customVersions`) with the ".0" patch added.

All type checks, formatting, tests, and build steps pass successfully.